### PR TITLE
internet: ARP cache problem thinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ The following interface is implemented by networking stack nodes and the stack t
 ```go
 type StackNode interface {
     // Encapsulate receives a buffer the receiver must fill with data. 
-    // The receiver's start byte is at carrierData[frameOffset].
-	Encapsulate(carrierData []byte, frameOffset int) (int, error)
+    // The receiver's start byte is at carrierData[offsetToFrame].
+	Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) (int, error)
 	// Demux receives a buffer the receiver must decode and pass on to corresponding child StackNode(s).
-    // The receiver's start byte is at carrierData[frameOffset].
-	Demux(carrierData []byte, frameOffset int) error
+    // The receiver's start byte is at carrierData[offsetToFrame].
+	Demux(carrierData []byte, offsetToFrame int) error
     // LocalPort returns the port of the node if applicable or zero. Used for UDP/TCP nodes.
 	LocalPort() uint16
     // Protocol returns the protocol of this node if applicable or zero. Usually either a ethernet.Type (EtherType) or lneto.IPProto (IP Protocol number).

--- a/arp/arp_test.go
+++ b/arp/arp_test.go
@@ -34,13 +34,13 @@ func TestHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 	var buf, discard [64]byte
-	n, err := c1.Encapsulate(buf[:], 0)
+	n, err := c1.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Fatal("error on should be nop send:", err)
 	} else if n > 0 {
 		t.Fatal("should not send if no query")
 	}
-	n, err = c2.Encapsulate(buf[:], 0)
+	n, err = c2.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Fatal("error on should be nop send:", err)
 	} else if n > 0 {
@@ -50,11 +50,11 @@ func TestHandler(t *testing.T) {
 	// Perform ARP exchange.
 	expectHWAddr := c2.ourHWAddr
 	queryAddr := c2.ourProtoAddr
-	err = c1.StartQuery(queryAddr)
+	err = c1.StartQuery(nil, queryAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
-	n, err = c1.Encapsulate(buf[:], 0) // Send Request.
+	n, err = c1.Encapsulate(buf[:], -1, 0) // Send Request.
 	if err != nil {
 		t.Fatal(err)
 	} else if n == 0 {
@@ -66,14 +66,14 @@ func TestHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	n, err = c2.Encapsulate(buf[:], 0) //  Send response.
+	n, err = c2.Encapsulate(buf[:], -1, 0) //  Send response.
 	if err != nil {
 		t.Fatal(err)
 	} else if n == 0 {
 		t.Fatal("got no response to request")
 	}
 	validateARP(t, buf[:])
-	n, err = c2.Encapsulate(discard[:], 0) // Double tap check, should send nothing.
+	n, err = c2.Encapsulate(discard[:], -1, 0) // Double tap check, should send nothing.
 	if err != nil {
 		t.Fatal("double tap send error:", err)
 	} else if n > 0 {
@@ -90,13 +90,13 @@ func TestHandler(t *testing.T) {
 	} else if !bytes.Equal(hwaddr, expectHWAddr) {
 		log.Fatalf("expected to get hwaddr %x!=%x", hwaddr, expectHWAddr)
 	}
-	n, err = c1.Encapsulate(buf[:], 0)
+	n, err = c1.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Fatal(err)
 	} else if n > 0 {
 		t.Fatal("expected no data")
 	}
-	n, err = c2.Encapsulate(buf[:], 0)
+	n, err = c2.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Fatal(err)
 	} else if n > 0 {

--- a/dhcpv4/dhcp_test.go
+++ b/dhcpv4/dhcp_test.go
@@ -28,7 +28,7 @@ func TestClientServer(t *testing.T) {
 	// CLIENT DISCOVER.
 	assertClState(StateInit)
 	var buf [1024]byte
-	n, err := cl.Encapsulate(buf[:], 0)
+	n, err := cl.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Fatal(err)
 	} else if n == 0 {
@@ -40,7 +40,7 @@ func TestClientServer(t *testing.T) {
 		t.Fatal(err)
 	}
 	// SERVER REPLY OFFER
-	n, err = sv.Encapsulate(buf[:], 0)
+	n, err = sv.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Fatal(err)
 	} else if n == 0 {
@@ -53,7 +53,7 @@ func TestClientServer(t *testing.T) {
 	assertClState(StateSelecting)
 
 	// CLIENT SEND OUT REQUEST.
-	n, err = cl.Encapsulate(buf[:], 0)
+	n, err = cl.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Fatal(err)
 	} else if n == 0 {
@@ -66,7 +66,7 @@ func TestClientServer(t *testing.T) {
 	}
 
 	// SERVER REPLIES WITH ACK.
-	n, err = sv.Encapsulate(buf[:], 0)
+	n, err = sv.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Fatal(err)
 	} else if n == 0 {
@@ -99,13 +99,13 @@ func TestExample(t *testing.T) {
 	})
 	buf := make([]byte, 2048)
 	buf2 := make([]byte, len(buf))
-	n, err := cl.Encapsulate(buf, 0)
+	n, err := cl.Encapsulate(buf, -1, 0)
 	if err != nil {
 		t.Fatal(err)
 	} else if n <= 0 {
 		t.Fatal("no data sent out by client after starting request")
 	}
-	n, err = cl.Encapsulate(buf2, 0)
+	n, err = cl.Encapsulate(buf2, -1, 0)
 	if err != nil {
 		t.Error("client encaps double tap after discover:", err)
 	}
@@ -141,13 +141,13 @@ func TestExample(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	n, err = cl.Encapsulate(buf[:], 0)
+	n, err = cl.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Fatal(err)
 	} else if n <= 0 {
 		t.Fatal("no data written from client in response to offer")
 	}
-	n, err = cl.Encapsulate(buf[:], 0)
+	n, err = cl.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Error("encapsulate double tap after request:", err)
 	} else if n > 0 {

--- a/dhcpv4/server.go
+++ b/dhcpv4/server.go
@@ -159,9 +159,9 @@ func (sv *Server) Demux(carrierData []byte, frameOffset int) error {
 	return nil
 }
 
-func (sv *Server) Encapsulate(carrierData []byte, frameOffset int) (int, error) {
-	carrierIsIP := frameOffset >= 28
-	dfrm, err := NewFrame(carrierData[frameOffset:])
+func (sv *Server) Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) (int, error) {
+	carrierIsIP := offsetToIP >= 0
+	dfrm, err := NewFrame(carrierData[offsetToFrame:])
 	optBuf := dfrm.OptionsPayload()[:]
 	if err != nil {
 		return 0, err
@@ -220,7 +220,7 @@ func (sv *Server) Encapsulate(carrierData []byte, frameOffset int) (int, error) 
 	copy(dfrm.CHAddrAs6()[:], client.hwaddr[:])
 	dfrm.SetMagicCookie(MagicCookie)
 	if carrierIsIP {
-		err = internal.SetIPAddrs(carrierData, 0, sv.siaddr[:], client.addr[:])
+		err = internal.SetIPAddrs(carrierData[offsetToIP:], 0, sv.siaddr[:], client.addr[:])
 		if err != nil {
 			return 0, err
 		}

--- a/dns/client.go
+++ b/dns/client.go
@@ -43,7 +43,7 @@ func (c *Client) StartResolve(localPort, txid uint16, cfg ResolveConfig) error {
 	return nil
 }
 
-func (c *Client) Encapsulate(carrierData []byte, frameOffset int) (int, error) {
+func (c *Client) Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) (int, error) {
 	if c.isClosed() {
 		return 0, net.ErrClosed
 	} else if c.state != dnsSendQuery {
@@ -51,7 +51,7 @@ func (c *Client) Encapsulate(carrierData []byte, frameOffset int) (int, error) {
 	}
 
 	msg := &c.msg
-	frame := carrierData[frameOffset:]
+	frame := carrierData[offsetToFrame:]
 	msglen := msg.Len()
 	if msglen > uint16(len(frame)) {
 		return 0, errCalcLen

--- a/examples/bridge/main.go
+++ b/examples/bridge/main.go
@@ -199,7 +199,7 @@ func run() (err error) {
 		prevState = state
 
 		clear(buf)
-		nwrite, err := stack.Encapsulate(buf[:], 0)
+		nwrite, err := stack.Encapsulate(buf[:], -1, 0)
 		if err != nil {
 			fmt.Println("ERR:ENCAPSULATE", err)
 		} else if nwrite > 0 {
@@ -267,10 +267,10 @@ func (s *Stack) Demux(b []byte, _ int) (err error) {
 	return s.link.Demux(b, 0)
 }
 
-func (s *Stack) Encapsulate(b []byte, _ int) (int, error) {
-	n, err := s.link.Encapsulate(b, 0)
+func (s *Stack) Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) (int, error) {
+	n, err := s.link.Encapsulate(carrierData, offsetToIP, offsetToFrame)
 	if n > 0 {
-		iframes, errpcap := s.shark.CaptureEthernet(s.aux[:0], b[:n], 0)
+		iframes, errpcap := s.shark.CaptureEthernet(s.aux[:0], carrierData[:n], 0)
 		if errpcap != nil {
 			fmt.Println("OU", iframes, errpcap.Error())
 		} else {
@@ -426,7 +426,7 @@ func (s *Stack) StartResolveHardwareAddress6(ip netip.Addr) error {
 		return errors.New("unsupported or invalid IP address")
 	}
 	addr := ip.As4()
-	return s.arp.StartQuery(addr[:])
+	return s.arp.StartQuery(nil, addr[:])
 }
 
 func (s *Stack) ResultResolveHardwareAddress6(ip netip.Addr) (hw [6]byte, err error) {

--- a/examples/stack/main.go
+++ b/examples/stack/main.go
@@ -107,7 +107,7 @@ func main() {
 			}
 		}
 
-		nw, err := stack.ethernet.Encapsulate(buf[:], 0)
+		nw, err := stack.ethernet.Encapsulate(buf[:], -1, 0)
 		if err != nil {
 			lg.Error("handle", slog.String("err", err.Error()))
 		} else if nw > 0 {
@@ -230,7 +230,7 @@ func (stack *Stack) Recv(b []byte) error {
 }
 
 func (stack *Stack) Send(b []byte) (int, error) {
-	return stack.ethernet.Encapsulate(b, 0)
+	return stack.ethernet.Encapsulate(b, -1, 0)
 }
 
 func (stack *Stack) OpenTCPListener(port uint16) (*internet.NodeTCPListener, error) {
@@ -239,7 +239,7 @@ func (stack *Stack) OpenTCPListener(port uint16) (*internet.NodeTCPListener, err
 	if err != nil {
 		return nil, err
 	}
-	err = stack.tcpports.Register(&listener)
+	err = stack.tcpports.Register(&listener) // Passive TCP requires no MAC setting.
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func (stack *Stack) OpenPassiveTCP(port uint16, iss tcp.Value) (*tcp.Conn, error
 	if err != nil {
 		return nil, err
 	}
-	err = stack.tcpports.Register(conn)
+	err = stack.tcpports.Register(conn) // Passive MAC with no listening.
 	if err != nil {
 		return nil, err
 	}

--- a/examples/stackbasic/main.go
+++ b/examples/stackbasic/main.go
@@ -232,7 +232,7 @@ func NewEthernetTCPStack(ourMAC, gwMAC [6]byte, ip netip.AddrPort, mtu uint16, s
 type handler struct {
 	raddr  []byte
 	recv   func([]byte, int) error
-	handle func([]byte, int) (int, error)
+	handle func([]byte, int, int) (int, error)
 	proto  ethernet.Type
 	lport  uint16
 }
@@ -295,7 +295,7 @@ func (ls *LinkStack) HandleEth(dst []byte) (n int, err error) {
 	copy(efrm.DestinationHardwareAddr()[:], ls.gwmac[:]) // default set the gateway.
 	for i := range ls.handlers {
 		h := &ls.handlers[i]
-		n, err = h.handle(dst[:mtu], 14)
+		n, err = h.handle(dst[:mtu], 14, 14)
 		if err != nil {
 			ls.error("handling", slog.String("proto", ethernet.Type(h.proto).String()), slog.String("err", err.Error()))
 			continue
@@ -322,8 +322,8 @@ func (as *ARPStack) Recv(EtherFrame []byte, arpOff int) error {
 	return as.handler.Demux(EtherFrame, arpOff)
 }
 
-func (as *ARPStack) Handle(EtherFrame []byte, arpOff int) (int, error) {
-	n, err := as.handler.Encapsulate(EtherFrame, arpOff)
+func (as *ARPStack) Handle(EtherFrame []byte, offsetToIP, arpOff int) (int, error) {
+	n, err := as.handler.Encapsulate(EtherFrame, offsetToIP, arpOff)
 	if err != nil || n == 0 {
 		return 0, err
 	}

--- a/examples/xnet/main.go
+++ b/examples/xnet/main.go
@@ -110,7 +110,7 @@ func run() (err error) {
 		var frames []pcap.Frame
 		for {
 			clear(buf)
-			nwrite, err := stack.Encapsulate(buf[:], 0)
+			nwrite, err := stack.Encapsulate(buf[:], -1, 0)
 			if err != nil {
 				fmt.Println("ERR:ENCAPSULATE", err)
 			} else if nwrite > 0 {

--- a/internal/ip.go
+++ b/internal/ip.go
@@ -56,3 +56,14 @@ func SetIPAddrs(buf []byte, id uint16, src, dst []byte) (err error) {
 	copy(dstaddr, dst)
 	return nil
 }
+
+// IsZeroed returns true if all arguments are set to their zero value.
+func IsZeroed[T comparable](a ...T) bool {
+	var z T
+	for i := range a {
+		if a[i] != z {
+			return false
+		}
+	}
+	return true
+}

--- a/internet/node-tcplistener.go
+++ b/internet/node-tcplistener.go
@@ -94,7 +94,7 @@ func (listener *NodeTCPListener) TryAccept() (*tcp.Conn, error) {
 }
 
 // Encapsulate implements [StackNode].
-func (listener *NodeTCPListener) Encapsulate(carrierData []byte, tcpFrameOffset int) (int, error) {
+func (listener *NodeTCPListener) Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) (int, error) {
 	if listener.isClosed() {
 		return 0, net.ErrClosed
 	}
@@ -102,7 +102,7 @@ func (listener *NodeTCPListener) Encapsulate(carrierData []byte, tcpFrameOffset 
 		if conn == nil {
 			continue
 		}
-		n, err := conn.Encapsulate(carrierData, tcpFrameOffset)
+		n, err := conn.Encapsulate(carrierData, offsetToIP, offsetToFrame)
 		if err != nil {
 			err = listener.maintainConn(listener.accepted, i, err)
 		}

--- a/internet/stack-ports.go
+++ b/internet/stack-ports.go
@@ -2,11 +2,15 @@ package internet
 
 import (
 	"encoding/binary"
+	"errors"
 	"io"
+	"log/slog"
 	"math"
 	"strconv"
 
 	"github.com/soypat/lneto"
+	"github.com/soypat/lneto/ethernet"
+	"github.com/soypat/lneto/internal"
 )
 
 type StackPorts struct {
@@ -14,6 +18,7 @@ type StackPorts struct {
 	handlers   handlers
 	dstPortOff uint16
 	protocol   uint16
+	// stores last node to demux/encapsulate.
 }
 
 func (ps *StackPorts) ResetUDP(maxNodes int) error {
@@ -46,11 +51,11 @@ func (ps *StackPorts) Protocol() uint64 { return uint64(ps.protocol) }
 
 func (ps *StackPorts) ConnectionID() *uint64 { return &ps.connID }
 
-func (ps *StackPorts) Encapsulate(b []byte, offset int) (n int, err error) {
-	if int(ps.dstPortOff)+offset+2 > len(b) {
+func (ps *StackPorts) Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) (n int, err error) {
+	if int(ps.dstPortOff)+offsetToFrame+2 > len(carrierData) {
 		return 0, io.ErrShortBuffer
 	}
-	_, n, err = ps.handlers.encapsulateAny(b, offset)
+	_, n, err = ps.handlers.encapsulateAny(carrierData, offsetToIP, offsetToFrame)
 	return n, err
 }
 
@@ -63,6 +68,8 @@ func (ps *StackPorts) Demux(b []byte, offset int) (err error) {
 	return err
 }
 
+// Register registers a port StackNode on StackPorts.
+// If dstMAC is set to non-nil, length six buffer then
 func (ps *StackPorts) Register(h StackNode) error {
 	port := h.LocalPort()
 	proto := h.Protocol()
@@ -72,4 +79,75 @@ func (ps *StackPorts) Register(h StackNode) error {
 		return errInvalidProto
 	}
 	return ps.handlers.registerByPortProto(nodeFromStackNode(h, port, proto, nil))
+}
+
+// StackPortsMACFiltered is a StackPorts implementation but that avoids calling encapsulate on nodes
+// with a non-nil MAC address registered via Register method that is set to all zero values.
+// If the address is set to nil no filtering occurs. MAC Address is set automatically on the ethernet frame by StackPortsMACFiltered when non-nil.
+type StackPortsMACFiltered struct {
+	sp StackPorts
+}
+
+func (mfsp *StackPortsMACFiltered) Register(h StackNode, addr []byte) error {
+	port := h.LocalPort()
+	proto := h.Protocol()
+	if port <= 0 {
+		return errZeroPort
+	} else if proto != uint64(mfsp.sp.protocol) {
+		return errInvalidProto
+	} else if addr != nil && len(addr) != 6 {
+		return errors.New("invalid MAC")
+	}
+	return mfsp.sp.handlers.registerByPortProto(nodeFromStackNode(h, port, proto, addr))
+}
+
+func (ps *StackPortsMACFiltered) ResetUDP(maxNodes int) error {
+	return ps.sp.ResetUDP(maxNodes)
+}
+
+func (ps *StackPortsMACFiltered) ResetTCP(maxNodes int) error {
+	return ps.sp.ResetTCP(maxNodes)
+}
+
+func (ps *StackPortsMACFiltered) Reset(protocol uint64, dstPortOffset uint16, maxNodes int) error {
+	return ps.sp.Reset(protocol, dstPortOffset, maxNodes)
+}
+
+func (ps *StackPortsMACFiltered) LocalPort() uint16 { return 0 }
+
+func (ps *StackPortsMACFiltered) Protocol() uint64 { return uint64(ps.sp.protocol) }
+
+func (ps *StackPortsMACFiltered) ConnectionID() *uint64 { return &ps.sp.connID }
+
+func (ps *StackPortsMACFiltered) Demux(b []byte, offset int) (err error) {
+	// No MAC Filtering on ingress. TODO?
+	return ps.sp.Demux(b, offset)
+}
+
+func (ps *StackPortsMACFiltered) Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) (n int, err error) {
+	if int(ps.sp.dstPortOff)+offsetToFrame+2 > len(carrierData) {
+		return 0, io.ErrShortBuffer
+	}
+	h := &ps.sp.handlers
+	for i := range h.nodes {
+		node := &h.nodes[i]
+		if node.IsInvalid() || (len(node.remoteAddr) > 0 && internal.IsZeroed(node.remoteAddr...)) {
+			continue
+		}
+		n, err = node.encapsulate(carrierData, offsetToIP, offsetToFrame)
+		if h.tryHandleError(node, err) {
+			err = nil // CLOSE error handled gracefully by deleting node.
+		}
+		if n > 0 {
+			if len(node.remoteAddr) == 6 && offsetToIP >= 14 {
+				efrm, _ := ethernet.NewFrame(carrierData[offsetToIP-14:])
+				*efrm.DestinationHardwareAddr() = [6]byte(node.remoteAddr)
+			}
+			return n, err
+		} else if err != nil {
+			// Make sure not to hang on one handler that keeps returning an error.
+			h.error("handlers:encapsulate", slog.String("func", "encapsulateAny"), slog.String("ctx", h.context), slog.String("err", err.Error()))
+		}
+	}
+	return 0, err // Return last written error.
 }

--- a/internet/stack-udpport.go
+++ b/internet/stack-udpport.go
@@ -61,24 +61,25 @@ func (sudp *StackUDPPort) Demux(carrierData []byte, frameOffset int) error {
 	return err
 }
 
-func (sudp *StackUDPPort) Encapsulate(carrierData []byte, frameOffset int) (int, error) {
+func (sudp *StackUDPPort) Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) (int, error) {
 	if sudp.h.IsInvalid() {
 		sudp.h.destroy()
 		return 0, net.ErrClosed
 	}
-	ufrm, err := udp.NewFrame(carrierData[frameOffset:])
+	ufrm, err := udp.NewFrame(carrierData[offsetToFrame:])
 	if err != nil {
 		return 0, err
 	}
 	ufrm.SetSourcePort(sudp.h.port)
 	ufrm.SetDestinationPort(sudp.rmport)
-	if len(sudp.raddr) > 0 && frameOffset >= 20 {
-		err = internal.SetIPAddrs(carrierData, 0, nil, sudp.raddr)
+	if len(sudp.raddr) > 0 && offsetToIP >= 0 {
+		err = internal.SetIPAddrs(carrierData[offsetToIP:], 0, nil, sudp.raddr)
 		if err != nil {
 			return 0, err
 		}
 	}
-	n, err := sudp.h.encapsulate(carrierData, frameOffset+8)
+	// Child payload starts 8 bytes after UDP header start.
+	n, err := sudp.h.encapsulate(carrierData, offsetToIP, offsetToFrame+8)
 	if n == 0 {
 		if err != nil {
 			slog.Error("stackudp:encapsulate", slog.String("err", err.Error()))

--- a/internet/stackbasic_test.go
+++ b/internet/stackbasic_test.go
@@ -44,7 +44,7 @@ func TestBasicStack2(t *testing.T) {
 
 func expectExchange(t *testing.T, from, to *StackIP, buf []byte) {
 	t.Helper()
-	n, err := from.Encapsulate(buf, 0)
+	n, err := from.Encapsulate(buf, -1, 0)
 	if err != nil {
 		t.Error("expectExchange:encapsulate:", err)
 	} else if n == 0 {

--- a/ntp/client.go
+++ b/ntp/client.go
@@ -50,11 +50,11 @@ func (c *Client) ConnectionID() *uint64 {
 	return &c.connID
 }
 
-func (c *Client) Encapsulate(carrierData []byte, frameOffset int) (int, error) {
+func (c *Client) Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) (int, error) {
 	if c.IsDone() {
 		return 0, nil
 	}
-	payload := carrierData[frameOffset:]
+	payload := carrierData[offsetToFrame:]
 	frm, err := NewFrame(payload)
 	if err != nil {
 		return 0, err

--- a/x/xnet/stack-async.go
+++ b/x/xnet/stack-async.go
@@ -73,11 +73,11 @@ func (s *StackAsync) Demux(carrierData []byte, etherOff int) error {
 	return s.link.Demux(carrierData, etherOff)
 }
 
-func (s *StackAsync) Encapsulate(carrierData []byte, etherOff int) (int, error) {
+func (s *StackAsync) Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	n, err := s.link.Encapsulate(carrierData, etherOff)
+	n, err := s.link.Encapsulate(carrierData, offsetToIP, offsetToFrame)
 	s.totalsent += uint64(n)
 	return n, err
 }
@@ -169,7 +169,7 @@ func (s *StackAsync) resetARP() error {
 	if addr.Is6() {
 		proto = ethernet.TypeIPv6
 	}
-	return s.arp.Reset(arp.HandlerConfig{
+	err := s.arp.Reset(arp.HandlerConfig{
 		HardwareAddr: mac[:],
 		ProtocolAddr: addr.AsSlice(),
 		MaxQueries:   3,
@@ -177,6 +177,14 @@ func (s *StackAsync) resetARP() error {
 		HardwareType: 1,
 		ProtocolType: proto,
 	})
+	if err != nil {
+		return err
+	}
+	err = s.link.Register(&s.arp)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Prand32 generates a pseudo random 32-bit unsigned integer from the internal state and advances the seed.
@@ -197,7 +205,9 @@ func (s *StackAsync) SetIPAddr(addr netip.Addr) error {
 	if err != nil {
 		return err
 	}
-	return s.resetARP()
+	ip := addr.As4()
+	err = s.arp.UpdateProtoAddr(ip[:])
+	return err
 }
 
 func (s *StackAsync) Addr() netip.Addr {
@@ -234,11 +244,23 @@ func (s *StackAsync) Gateway6() [6]byte {
 func (s *StackAsync) DialTCP(conn *tcp.Conn, localPort uint16, addrp netip.AddrPort) (err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	var mac []byte
+	if s.dhcpResults.Subnet.Contains(addrp.Addr()) {
+		mac = make([]byte, 6)
+		ip := addrp.Addr().As4()
+		// StartQuery starts an ARP query for addresses in this network.
+		// On finishing query MAC is set and thus the StackPort will allow encapsulating
+		// data on that connection.
+		err = s.arp.StartQuery(mac, ip[:])
+		if err != nil {
+			return err
+		}
+	}
 	err = conn.OpenActive(localPort, addrp, tcp.Value(s.Prand32()))
 	if err != nil {
 		return err
 	}
-	err = s.tcps.Register(conn)
+	err = s.tcps.Register(conn) // MAC is set later on by ARP response arriving to our network.
 	if err != nil {
 		conn.Abort()
 		return err
@@ -376,7 +398,7 @@ func (s *StackAsync) StartResolveHardwareAddress6(ip netip.Addr) error {
 		return errors.New("unsupported or invalid IP address")
 	}
 	addr := ip.As4()
-	return s.arp.StartQuery(addr[:])
+	return s.arp.StartQuery(nil, addr[:])
 }
 
 // ResultResolveHardwareAddress6
@@ -436,12 +458,7 @@ func (stack *StackAsync) AssimilateDHCPResults(results *DHCPResults) error {
 	stack.mu.Lock()
 	defer stack.mu.Unlock()
 	if results.AssignedAddr.IsValid() {
-		err := stack.ip.SetAddr(results.AssignedAddr)
-		if err != nil {
-			return err
-		}
-		// Reset ARP handler with new IP address so it can respond to ARP requests.
-		err = stack.resetARP()
+		err := stack.SetIPAddr(results.AssignedAddr)
 		if err != nil {
 			return err
 		}

--- a/x/xnet/xnet_test.go
+++ b/x/xnet/xnet_test.go
@@ -322,7 +322,7 @@ func (tst *tester) TCPExchange(expect tcpExpectExchange, stack1, stack2 *StackAs
 	default:
 		panic("OOB")
 	}
-	n, err := src.Encapsulate(buf[:], 0)
+	n, err := src.Encapsulate(buf[:], -1, 0)
 	if err != nil {
 		t.Fatal(err)
 	} else if n == 0 {


### PR DESCRIPTION
@ddirect added a intermediary data structure called handlers based on your round robin implementation but without the round robin (want to start out simple, you may add the round robin aspect it in a later PR).

By using methods on the handler type we can ensure the nodes are always handled correctly:
- destroyed when net.Errclosed encountered
- Nodes iterated over gracefully when encapsulating to ensure we don't block on a node that returns error over and over again

This is helping me think so far. no logic on how to solve ARP cache issue.