### PR TITLE
arp: fixes to implementation

### DIFF
--- a/arp/definitions.go
+++ b/arp/definitions.go
@@ -13,7 +13,7 @@ const (
 var (
 	errARPBufferFull  = errors.New("ARP client need handling:too many ops pending")
 	errShortARP       = errors.New("packet too short to be ARP")
-	errARPUnsupported = errors.New("ARP not supprortedf")
+	errARPUnsupported = errors.New("ARP not supported")
 	errLargeSizes     = errors.New("size of ARP protocol+hardware is unusually large")
 )
 

--- a/arp/handler.go
+++ b/arp/handler.go
@@ -129,8 +129,14 @@ func (h *Handler) DiscardQuery(protoAddr []byte) error {
 func (h *Handler) compactQueries() {
 	validOff := 0
 	for i := 0; i < len(h.queries); i++ {
-		if h.queries[i].isInvalid() {
-			h.queries[validOff] = h.queries[i]
+		if !h.queries[i].isInvalid() {
+			if i != validOff {
+				// We swap the queries here so that when `StartQuery` extends
+				// queries slice, we don't have sharing of the internal structures.
+				// An alternative would be to zero things, however that would incur
+				// an allocation cost.
+				h.queries[validOff], h.queries[i] = h.queries[i], h.queries[validOff]
+			}
 			validOff++
 		}
 	}


### PR DESCRIPTION
* typo in error text
* compactQueries was keeping invalid queries
* compactQueries accidentally ended up creating shared slices