### PR TITLE
Repeating select call on Bridge when interrupted

### DIFF
--- a/internal/tap.go
+++ b/internal/tap.go
@@ -284,10 +284,12 @@ func (br *Bridge) Poll(timeout time.Duration) (bool, error) {
 		Sec:  int64(timeout / time.Second),
 		Usec: int64((timeout % time.Second) / time.Microsecond),
 	}
+	retry := 0
 again:
 	n, err := syscall.Select(br.fd+1, &readfds, nil, nil, &tv)
+	retry++
 	if err != nil {
-		if err == syscall.EINTR {
+		if err == syscall.EINTR && retry <= 10 {
 			// under linux, select updates tv with the remaining time
 			goto again
 		}


### PR DESCRIPTION
I had some trouble with the select call used to wait data on the raw socket ("Bridge") which lneto examples use under Linux. It seems that the operation is interrupted from time to time on my bare metal Ubuntu 24.04, and in those cases it needs to be repeated.
Note that the "Tap" select call may need to be patched too.