### PR TITLE
Ignoring packet padding for IPv4 TCP capture

### DIFF
--- a/internet/pcap/capture.go
+++ b/internet/pcap/capture.go
@@ -195,6 +195,8 @@ func (pc *PacketBreakdown) CaptureIPv4(dst []Frame, pkt []byte, bitOffset int) (
 	if pc.validator().HasError() {
 		return dst, pc.validator().ErrPop()
 	}
+	// limit packet to the actual IPv4 frame size
+	pkt = pkt[:bitOffset/8+int(ifrm4.TotalLength())]
 	finfo := Frame{
 		Protocol:        ethernet.TypeIPv4,
 		PacketBitOffset: bitOffset,


### PR DESCRIPTION
I noticed that TCP packet capture was reporting non zero lengths for ACK packets without payload received from the network. These packets typically have a couple of padding bytes to get to the minimum 60 bytes length of Ethernet. The problem derives from the fact that the whole packet is sent over to the higher level parsers, including the padding, and the actual IP frame size is ignored.
This can be fixed in various ways: here I'm clamping the packet passed over as soon as IP has validated the frame size.

I decided to modify the test by adding some padding and verify that it's not present in the payload. In the process I discovered that the test packet was containing lots of random data generated by `AppendRandomIPv4TCPPacket`, which remained before the actual HTTP payload. The test was working the same since it was probably discarding all that stuff as "Headers".
Now I'm overwriting the random data with the actual HTTP payload and also using the correct `DATALEN` so that the payload and padding are detected correctly.

Note that `CaptureIPv6` may need a similar change.