### PR TITLE
TCP Conn Write backoff used to wait for the TX buffer to have enough room

### DIFF
--- a/internal/ring.go
+++ b/internal/ring.go
@@ -9,8 +9,7 @@ import (
 )
 
 var (
-	errRingBufferFull = errors.New("lneto/ring: buffer full")
-	errRingNoData     = errors.New("lneto/ring: empty write")
+	errRingNoData = errors.New("lneto/ring: empty write")
 )
 
 // Ring implements basic Ring buffer functionality.
@@ -39,7 +38,7 @@ func (r *Ring) WriteLimited(b []byte, limitOffset int) (int, error) {
 	}
 	limit := r.FreeLimited(limitOffset)
 	if len(b) > limit {
-		return 0, errRingBufferFull
+		return 0, nil
 	}
 	return r.Write(b)
 }
@@ -50,12 +49,12 @@ func (r *Ring) WriteString(s string) (int, error) {
 }
 
 // Write appends data to the ring buffer that can then be read back in order with [Ring.Read] methods.
-// An error is returned if length of data too large for buffer. Write is guaranteed to start at buffer index [Ring.Off].
+// 0,nil is returned if length of data too large for buffer. Write is guaranteed to start at buffer index [Ring.Off].
 func (r *Ring) Write(b []byte) (int, error) {
 	if len(b) == 0 {
 		return 0, errRingNoData
 	} else if r.IsFull() || r.Free() < len(b) {
-		return 0, errRingBufferFull
+		return 0, nil
 	}
 	midFree := r.midFree()
 	if midFree > 0 {

--- a/internal/ring_test.go
+++ b/internal/ring_test.go
@@ -329,8 +329,8 @@ func TestRingOverwrite(t *testing.T) {
 					panic("invalid test")
 				}
 				ngot, err := r.Write(auxbuf[:osz])
-				if err == nil {
-					t.Fatal("expected error")
+				if err != nil {
+					t.Fatal("expected no error")
 				} else if ngot > 0 {
 					t.Fatalf("expected no data written, got %d", ngot)
 				}

--- a/tcp/txqueue_test.go
+++ b/tcp/txqueue_test.go
@@ -69,13 +69,9 @@ func TestRingTx_op(t *testing.T) {
 				case opWrite:
 					// oplen=number of bytes to write into unsent buffer.
 					nwgot, err := rtx.Write(opWriteData)
-					wantErr := oplen > free
 					if err != nil && oplen <= free {
 						t.Fatal(itest, iop, err)
 					} else if err == nil {
-						if wantErr {
-							panic("wanted write error")
-						}
 						nunsent += nwgot
 						dataWritten = append(dataWritten, opWriteData[:nwgot]...)
 					} else if log {


### PR DESCRIPTION
@soypat Just a proposal, I thought it was faster to show you directly with a PR.
We discussed about using `Conn.AvailableOutput()` to determine if it's possible to send data on a TCP Conn without getting the `buffer full` error. After working on backoff, I realized that Conn.Write already has a mechanism to do this (the backoff). But the ring buffer needs to return (0, nil) (no error) in order to have the backoff mechanism being activated.

This change works fine in my tests and allows me to drop the `Conn.AvailableOutput()` check before writing. 

Alternatively, we could continue to return `errRingBufferFull` from the ring buffer, and detect that condition inside Conn.Write, to activate the backoff.