### PR TITLE
tcp.Conn.Write waits for enough buffer to be available instead of returning "buffer full"

### DIFF
--- a/internal/ring.go
+++ b/internal/ring.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	errRingBufferFull = errors.New("lneto/ring: buffer full")
+	ErrRingBufferFull = errors.New("lneto/ring: buffer full")
 	errRingNoData     = errors.New("lneto/ring: empty write")
 )
 
@@ -39,7 +39,7 @@ func (r *Ring) WriteLimited(b []byte, limitOffset int) (int, error) {
 	}
 	limit := r.FreeLimited(limitOffset)
 	if len(b) > limit {
-		return 0, errRingBufferFull
+		return 0, ErrRingBufferFull
 	}
 	return r.Write(b)
 }
@@ -55,7 +55,7 @@ func (r *Ring) Write(b []byte) (int, error) {
 	if len(b) == 0 {
 		return 0, errRingNoData
 	} else if r.IsFull() || r.Free() < len(b) {
-		return 0, errRingBufferFull
+		return 0, ErrRingBufferFull
 	}
 	midFree := r.midFree()
 	if midFree > 0 {

--- a/tcp/conn.go
+++ b/tcp/conn.go
@@ -218,7 +218,7 @@ func (conn *Conn) Write(b []byte) (int, error) {
 		conn.mu.Unlock()
 		n += ngot
 		b = b[ngot:]
-		if err != nil || n == plen {
+		if (err != nil && err != internal.ErrRingBufferFull) || n == plen {
 			break
 		} else if ngot > 0 {
 			backoff.Hit()


### PR DESCRIPTION
If the ring buffer reports that not enough space is available, Write uses backoff to wait.
Also see https://github.com/soypat/lneto/pull/30