### PR TITLE
TCP: advertising the currently available receive window size

### DIFF
--- a/tcp/handler.go
+++ b/tcp/handler.go
@@ -255,6 +255,7 @@ func (h *Handler) Send(b []byte) (int, error) {
 		var ok bool
 		available := min(buffered, len(b)-sizeHeaderTCP)
 		segment, ok = h.scb.PendingSegment(available)
+		segment.WND = Size(h.bufRx.Free())
 		if !ok {
 			// No pending control segment or data to send. Yield.
 			return 0, nil


### PR DESCRIPTION
Currently lneto always advertises as TCP receive window the full receive buffer size, even if part (or all) of this buffer contains data already received from the network, but still not read from Conn.
In my usual performance tests, I'm connecting to a server which sends data as quickly as possible. Since lneto advertises a window which may be larger than what it can actually receive, Demux ends up returning "rx buffer full" after little time (even if reading data from Conn as quickly as possible). This indicates that the server has sent a segment which wouldn't fit the lneto receive window.

This fix ensures that the TCP receive window advertised in every segment matches the current available size of the receive buffer. I've been testing this fix for a while now, while working on the other PRs, and I don't get the Demux error any more. Window sizes look good on Wireshark.