### PR TITLE
tcp: bugfix for missing ack for window rejected segments

### DIFF
--- a/tcp/control.go
+++ b/tcp/control.go
@@ -445,6 +445,14 @@ func (tcb *ControlBlock) validateIncomingSegment(seg Segment) (err error) {
 		err = errRequireSequential
 	}
 	if err != nil {
+		// RFC 9293 §3.4: If segment not acceptable, send ACK (unless RST).
+		switch err {
+		case errSeqNotInWindow, errLastNotInWindow, errRequireSequential, errZeroWindow:
+			if !flags.HasAny(FlagRST) {
+				tcb.challengeAck = true
+				tcb.pending[0] |= FlagACK
+			}
+		}
 		return err
 	}
 	if flags.HasAny(FlagRST) {


### PR DESCRIPTION
`validateIncomingSegment()` in `tcp/control.go:447-449` silently drops segments that fail the RFC 9293 §3.4 acceptability test without sending an ACK.

Testing:

Add a test modeled on `TestSYNOnEstablished_ChallengeACK` (seqsbug_test.go:116-163) that:
1. Sets up ESTABLISHED connection with advanced `rcv.NXT`
2. Sends a segment with `SEQ < rcv.NXT` (retransmission of acknowledged data)
3. Verifies `Recv()` returns error and `PendingSegment(0)` yields `Flags=FlagACK, SEQ=snd.NXT, ACK=rcv.NXT, WND=rcv.WND`
