### PR TITLE
tcp: bugfix for challenge ack panic edge case

### DIFF
--- a/tcp/handler.go
+++ b/tcp/handler.go
@@ -282,7 +282,7 @@ func (h *Handler) Send(b []byte) (int, error) {
 			// No pending control segment or data to send. Yield.
 			return 0, nil
 		}
-		if available > 0 {
+		if segment.DATALEN > 0 {
 			n, err := h.bufTx.MakePacket(b[sizeHeaderTCP:sizeHeaderTCP+segment.DATALEN], segment.SEQ)
 			if err != nil {
 				return 0, err


### PR DESCRIPTION
Observed: `panic: new sent packet offset must match last sent packet end`
This PR contains the one-line fix and a regression test

# AI explanation

## Summary

A challenge ACK triggered by an out-of-order segment causes `Handler.Send` to call `MakePacket` with a zero-length buffer, creating a degenerate zero-data entry in the TX sent packet list. The next real data send panics because the new packet's offset is inconsistent with this degenerate entry.

## Timeline (from logs.out, connection :80↔:41752)

| Time | Event |
|------|-------|
| 18:52:20.134–.138 | Four `TCPConn.Write` calls buffer ~1253 bytes for transmission |
| 18:52:20.140 | RX segment arrives with `seg.seq=3967129006`, but `rcv.nxt=3967129003` |
| 18:52:20.146 | Segment rejected: `seq != rcv.nxt`. `challengeAck` flag set |
| 18:52:20.151 | `Send()` called. `PendingSegment` returns challenge ACK (`DATALEN=0`, `ok=true`) |
| 18:52:20.151 | **Bug**: `MakePacket` called with 0-byte buffer → degenerate `{off:0, end:0, size:0}` packet added to sentlist |
| 18:52:20.155 | `TCPConn.Close` called |
| 18:52:20.159 | `Send()` called again. `PendingSegment` returns `DATALEN=1253` with `PSH,ACK` |
| 18:52:20.159 | `AddPacket` checks: `off==0 && lastPkt.end(0) != bufsize` → **panic** |

## Root Cause

`handler.go:279` — the guard before calling `MakePacket`:

```go
if available > 0 {  // BUG: checks TX buffer, not segment payload
    n, err := h.bufTx.MakePacket(b[sizeHeaderTCP:sizeHeaderTCP+segment.DATALEN], segment.SEQ)
```

`available` reflects unsent data in the TX ring buffer. `segment.DATALEN` reflects what `PendingSegment` allocated to this specific segment. These can diverge when `PendingSegment` returns a control-only segment (DATALEN=0) despite data being buffered:

- **Challenge ACK path** (`control.go:186–188`): Returns immediately with a pure ACK, bypasses all payload logic.
- **CLOSE_WAIT path** (already documented in `TestWriteAfterRemoteFIN`): Same class of divergence.

When `available > 0` but `segment.DATALEN == 0`, `MakePacket` receives a zero-length slice, reads zero bytes from the unsent ring, and adds a `{off:0, end:0, size:0}` entry to the sentlist. On the next call, `AddPacket` sees `off==0` and `lastPkt.end==0 != bufsize`, which violates the ring contiguity invariant.

## Fix

`handler.go:279` — change the guard from `available > 0` to `segment.DATALEN > 0`:

```go
if segment.DATALEN > 0 {
    n, err := h.bufTx.MakePacket(b[sizeHeaderTCP:sizeHeaderTCP+segment.DATALEN], segment.SEQ)
```

This ensures `MakePacket` is only called when `PendingSegment` has actually allocated payload bytes to the segment.

## Notes

- This is the same class of bug as the one tested by `TestWriteAfterRemoteFIN` (`handler_test.go:552`), which documents the CLOSE_WAIT variant. That test should also be verified to pass with this fix.
- A regression test for the challenge ACK variant (ESTABLISHED + out-of-order segment + buffered TX data) should be added.
- The out-of-order segment itself (`seg.seq` 3 bytes ahead of `rcv.nxt`) is a separate issue — lneto's strict sequential-only receive policy caused the gap. This is expected behavior per the stack's design, but the challenge ACK response must not corrupt internal TX state.
