### PR TITLE
Bump minimum Go version to 1.24

### DIFF
--- a/dhcpv4/client.go
+++ b/dhcpv4/client.go
@@ -153,10 +153,7 @@ func (c *Client) Encapsulate(carrierData []byte, offsetToIP, offsetToFrame int) 
 		numOpts += n
 		n, _ = EncodeOption(opts[numOpts:], OptParameterRequestList, defaultParamReqList...)
 		numOpts += n
-		maxlen := len(dst)
-		if maxlen > math.MaxUint16 {
-			maxlen = math.MaxUint16
-		}
+		maxlen := min(len(dst), math.MaxUint16)
 		n, _ = EncodeOption16(opts[numOpts:], OptMaximumMessageSize, uint16(maxlen))
 		numOpts += n
 		if c.reqIP.valid {

--- a/dhcpv4/server_test.go
+++ b/dhcpv4/server_test.go
@@ -106,7 +106,7 @@ func TestServerMultipleClients(t *testing.T) {
 	}
 
 	// All assigned addresses must be unique.
-	for i := 0; i < nClients; i++ {
+	for i := range nClients {
 		for j := i + 1; j < nClients; j++ {
 			if assignedAddrs[i] == assignedAddrs[j] {
 				t.Errorf("clients %d and %d got same address %v", i, j, assignedAddrs[i])
@@ -123,7 +123,7 @@ func TestServerSequentialAddressAllocation(t *testing.T) {
 	sv.Configure(testServerConfig(svAddr))
 
 	// Build raw DISCOVER frames for two clients.
-	for i := byte(0); i < 2; i++ {
+	for i := range byte(2) {
 		var buf [512]byte
 		frm, _ := NewFrame(buf[:])
 		frm.ClearHeader()
@@ -147,7 +147,7 @@ func TestServerSequentialAddressAllocation(t *testing.T) {
 
 	// Encapsulate both OFFERs and verify addresses are in expected range.
 	var seen [2][4]byte
-	for i := byte(0); i < 2; i++ {
+	for i := range byte(2) {
 		var buf [512]byte
 		n, err := sv.Encapsulate(buf[:], -1, 0)
 		if err != nil {

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -489,7 +489,7 @@ func NewName(domain string) (Name, error) {
 // Returns an empty Name if n exceeds the number of labels.
 func (n Name) TrimLabels(skip int) Name {
 	off := 0
-	for i := 0; i < skip; i++ {
+	for range skip {
 		if off >= len(n.data) {
 			return Name{}
 		}

--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -195,32 +195,32 @@ func TestMessageAppendEncodeIncompleteOK(t *testing.T) {
 
 func (m *Message) String() string {
 	// s := fmt.Sprintf("Message: %#v\n", &m.Header)
-	var s string
+	var s strings.Builder
 	if len(m.Questions) > 0 {
-		s += "-- Questions\n"
+		s.WriteString("-- Questions\n")
 		for _, q := range m.Questions {
-			s += fmt.Sprintf("%#v\n", q)
+			s.WriteString(fmt.Sprintf("%#v\n", q))
 		}
 	}
 	if len(m.Answers) > 0 {
-		s += "-- Answers\n"
+		s.WriteString("-- Answers\n")
 		for _, a := range m.Answers {
-			s += fmt.Sprintf("%#v\n", a)
+			s.WriteString(fmt.Sprintf("%#v\n", a))
 		}
 	}
 	if len(m.Authorities) > 0 {
-		s += "-- Authorities\n"
+		s.WriteString("-- Authorities\n")
 		for _, ns := range m.Authorities {
-			s += fmt.Sprintf("%#v\n", ns)
+			s.WriteString(fmt.Sprintf("%#v\n", ns))
 		}
 	}
 	if len(m.Additionals) > 0 {
-		s += "-- Additionals\n"
+		s.WriteString("-- Additionals\n")
 		for _, e := range m.Additionals {
-			s += fmt.Sprintf("%#v\n", e)
+			s.WriteString(fmt.Sprintf("%#v\n", e))
 		}
 	}
-	return s
+	return s.String()
 }
 
 func TestDecodeMessage(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/soypat/lneto
 
-go 1.23.8
+go 1.24

--- a/http/httpraw/cookie.go
+++ b/http/httpraw/cookie.go
@@ -76,7 +76,7 @@ func (c *Cookie) Parse() error {
 
 func (c *Cookie) ForEach(cb func(key, value []byte) error) error {
 	nc := len(c.kvs)
-	for i := 0; i < nc; i++ {
+	for i := range nc {
 		kv := c.kvs[i]
 		key := tok2bytes(c.buf, kv.key)
 		value := tok2bytes(c.buf, kv.value)
@@ -91,7 +91,7 @@ func (c *Cookie) ForEach(cb func(key, value []byte) error) error {
 // Get gets a cookie's value from its key. Use HasValueOrKey to check if a key or single-valued cookie is present in the cookie.
 func (c *Cookie) Get(key string) []byte {
 	nc := len(c.kvs)
-	for i := 0; i < nc; i++ {
+	for i := range nc {
 		kv := c.kvs[i]
 		if b2s(tok2bytes(c.buf, kv.key)) == key {
 			return tok2bytes(c.buf, kv.value)
@@ -102,7 +102,7 @@ func (c *Cookie) Get(key string) []byte {
 
 func (c *Cookie) HasKeyOrSingleValue(keyOrSingleValue string) bool {
 	nc := len(c.kvs)
-	for i := 0; i < nc; i++ {
+	for i := range nc {
 		kv := c.kvs[i]
 		if kv.key.len == 0 && b2s(tok2bytes(c.buf, kv.value)) == keyOrSingleValue ||
 			b2s(tok2bytes(c.buf, kv.key)) == keyOrSingleValue {
@@ -159,7 +159,7 @@ func (c *Cookie) String() string {
 // AppendKeyValues appends the HTTP header value of the cookie expected after the "Cookie:" string. Does not include trailing \r\n's.
 func (c *Cookie) AppendKeyValues(dst []byte) []byte {
 	nc := len(c.kvs)
-	for i := 0; i < nc; i++ {
+	for i := range nc {
 		kv := c.kvs[i]
 		key := tok2bytes(c.buf, kv.key)
 		value := tok2bytes(c.buf, kv.value)

--- a/http/httpraw/header.go
+++ b/http/httpraw/header.go
@@ -199,7 +199,7 @@ func (h *Header) ForEach(cb func(key, value []byte) error) error {
 
 func (hb *headerBuf) forEach(cb func(key, value []byte) error) error {
 	nh := len(hb.headers)
-	for i := 0; i < nh; i++ {
+	for i := range nh {
 		kv := hb.headers[i]
 		if !kv.isValid() {
 			continue

--- a/http/httpraw/parse_test.go
+++ b/http/httpraw/parse_test.go
@@ -533,10 +533,7 @@ func TestParseRequest_InvalidHeaderSpaceBeforeColon(t *testing.T) {
 func splitInto(s string, n int) []string {
 	var chunks []string
 	for len(s) > 0 {
-		end := n
-		if end > len(s) {
-			end = len(s)
-		}
+		end := min(n, len(s))
 		chunks = append(chunks, s[:end])
 		s = s[end:]
 	}

--- a/internal/backoff.go
+++ b/internal/backoff.go
@@ -13,10 +13,8 @@ func BackoffConnRW(consecutiveBackoffs uint) {
 		maxShift       = 22
 		_overflowCheck = minWait << maxShift
 	)
-	wait := minWait << min(consecutiveBackoffs, maxShift)
-	if wait > maxWait {
-		wait = maxWait
-	}
+	shifted := minWait << min(consecutiveBackoffs, maxShift)
+	wait := min(shifted, maxWait)
 	time.Sleep(time.Duration(wait))
 }
 
@@ -31,9 +29,7 @@ func BackoffStackProto(consecutiveBackoffs uint) {
 		maxShift       = 22
 		_overflowCheck = minWait << maxShift
 	)
-	wait := minWait << min(consecutiveBackoffs, maxShift)
-	if wait > maxWait {
-		wait = maxWait
-	}
+	shifted := minWait << min(consecutiveBackoffs, maxShift)
+	wait := min(shifted, maxWait)
 	time.Sleep(time.Duration(wait))
 }

--- a/internal/ltesto/ltesto.go
+++ b/internal/ltesto/ltesto.go
@@ -489,11 +489,8 @@ func mutateTCPOptions(opts []byte, seed int64, variant int64) int64 {
 		}
 	case 4: // SACK with garbage block data.
 		if len(opts) >= 10 {
-			opts[0] = byte(tcp.OptSACK) // kind=5
-			sackLen := len(opts)
-			if sackLen > 34 {
-				sackLen = 34 // max 4 SACK blocks
-			}
+			opts[0] = byte(tcp.OptSACK)   // kind=5
+			sackLen := min(len(opts), 34) // max 4 SACK blocks
 			opts[1] = byte(sackLen)
 			for i := 2; i < sackLen; i++ {
 				opts[i] = byte(seed)

--- a/internal/ring_test.go
+++ b/internal/ring_test.go
@@ -20,7 +20,7 @@ func TestRing(t *testing.T) {
 	}
 	const data = "hello"
 	// Set random data and write some more and read it back.
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		nfirst := max(1, rng.Intn(bufSize)/2)
 		nsecond := max(1, rng.Intn(bufSize)/2)
 		if nfirst+nsecond > bufSize {
@@ -59,7 +59,7 @@ func TestRing(t *testing.T) {
 	var zeros [bufSize]byte
 
 	// Set random data and write some more and read it back with ReadAt and ReadPeek and ReadDiscard.
-	for i := 0; i < 32; i++ {
+	for range 32 {
 		nfirst := rng.Intn(len(data))/2 + 1 // write garbage data first.
 		nsecond := rng.Intn(len(data))/2 + 1
 		if nfirst+nsecond > bufSize {
@@ -72,7 +72,7 @@ func TestRing(t *testing.T) {
 		content = append(content, data[:nsecond]...)
 		setRingData(t, r, randOff, content)
 		// Two-tap ReadPeek to make sure pointer not advanced.
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			n, err = r.ReadPeek(readback[:])
 			if err != nil && err != io.EOF {
 				t.Fatal("read failed", err)
@@ -87,7 +87,7 @@ func TestRing(t *testing.T) {
 		}
 
 		// Two-tap ReadAt to make sure pointer not advanced.
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			off := rng.Intn(nfirst + nsecond)
 			n, err = r.ReadAt(readback[:nfirst+nsecond-off], int64(off))
 
@@ -135,7 +135,7 @@ func TestRing2(t *testing.T) {
 	ringbuf := make([]byte, maxsize)
 	auxbuf := make([]byte, maxsize)
 	rng.Read(data)
-	for i := 0; i < ntests; i++ {
+	for i := range ntests {
 		dsize := max(rng.Intn(len(data)), 1)
 		if !testRing1_loopback(t, rng, ringbuf, data[:dsize], auxbuf) {
 			t.Fatalf("failed test %d", i)
@@ -156,7 +156,7 @@ func TestRingEmpty(t *testing.T) {
 		for _, isonReadEndCalled := range []bool{false, true} {
 			name := fmt.Sprintf("reset=%v readend=%v", isResetCalled, isonReadEndCalled)
 			t.Run(name, func(t *testing.T) {
-				for off := 0; off < bufSize+1; off++ {
+				for off := range bufSize + 1 {
 					r.End = 0
 					r.Off = off
 					if isResetCalled {
@@ -201,7 +201,7 @@ func TestRingNonEmpty(t *testing.T) {
 				name := fmt.Sprintf("readend=%v checkWrite=%v checkRead=%v", isonReadEndCalled, checkWrite, checkRead)
 				t.Run(name, func(t *testing.T) {
 					for end := 1; end < bufSize+1; end++ {
-						for off := 0; off < bufSize+1; off++ {
+						for off := range bufSize + 1 {
 							r.End = end
 							r.Off = off
 							buf := r.Buffered()
@@ -251,7 +251,7 @@ func TestRing_OffWrite(t *testing.T) {
 	var rawbuf, auxbuf, readback [bufSize]byte
 	r := &Ring{Buf: rawbuf[:]}
 	for n := 1; n < bufSize+1; n++ {
-		for off := 0; off < bufSize+1; off++ {
+		for off := range bufSize + 1 {
 			r.Off = off // Start write at off.
 			r.End = 0   // Reset to use no data.
 			for i := 0; i < n; i++ {
@@ -288,7 +288,7 @@ func TestRing_TwoWrite(t *testing.T) {
 	var rawbuf, auxbuf, readback [bufSize]byte
 	r := &Ring{Buf: rawbuf[:]}
 
-	for i := 0; i < 1024; i++ {
+	for range 1024 {
 		n1 := rng.Intn(bufSize-1) + 1 // leave space for one more write
 		n2 := rng.Intn(bufSize-n1) + 1
 		off := rng.Intn(bufSize + 1)
@@ -319,8 +319,8 @@ func TestRingOverwrite(t *testing.T) {
 	const bufSize = 8
 	var rawbuf, auxbuf [bufSize]byte
 	r := &Ring{Buf: rawbuf[:]}
-	for off := 0; off < bufSize+1; off++ {
-		for buf := 0; buf < bufSize+1; buf++ {
+	for off := range bufSize + 1 {
+		for buf := range bufSize + 1 {
 			setRingData(t, r, off, rawbuf[:buf])
 			// Select write size overwriting data.
 			for osz := bufSize - buf + 1; osz < bufSize+1; osz++ {
@@ -403,7 +403,7 @@ func TestRing_findcrash(t *testing.T) {
 	rng := rand.New(rand.NewSource(0))
 	data := make([]byte, maxsize)
 
-	for i := 0; i < ntests; i++ {
+	for i := range ntests {
 		free := r.Free()
 		if free < 0 {
 			t.Fatal("free < 0")
@@ -448,7 +448,7 @@ func TestRingFreeLimited(t *testing.T) {
 	rng := rand.New(rand.NewSource(1))
 	buffer := make([]byte, n)
 	r := Ring{Buf: buffer}
-	for itest := 0; itest < 100000; itest++ {
+	for itest := range 100000 {
 		r.Off = rng.Intn(n)
 		r.End = rng.Intn(n + 1)
 		limit := rng.Intn(n)

--- a/internal/slices.go
+++ b/internal/slices.go
@@ -32,7 +32,7 @@ func DeleteZeroed[T comparable](a []T) []T {
 	var z T
 	off := 0
 	deleted := false
-	for i := 0; i < len(a); i++ {
+	for i := range a {
 		if a[i] != z {
 			if deleted {
 				a[off] = a[i]

--- a/internet/pcap/capture.go
+++ b/internet/pcap/capture.go
@@ -771,7 +771,7 @@ func appendField(dst, pkt []byte, fieldBitStart, bitlen int, rightAligned bool) 
 		if octets+octetsStart+1 > len(pkt) {
 			return dst, lneto.ErrShortBuffer
 		}
-		for i := 0; i < octets; i++ {
+		for i := range octets {
 			b := (pkt[octetsStart+i] & mask) << (8 - firstBitOffset)
 			b |= pkt[octetsStart+i+1] >> firstBitOffset
 			dst = append(dst, b)

--- a/internet/tcplistener_test.go
+++ b/internet/tcplistener_test.go
@@ -160,7 +160,7 @@ func TestListener_MultiConn(t *testing.T) {
 	var buf [2048]byte
 
 	// Complete full handshakes for all clients.
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		expectExchange(t, &clientStacks[i], &serverStack, buf[:]) // SYN
 		expectExchange(t, &serverStack, &clientStacks[i], buf[:]) // SYN-ACK
 		expectExchange(t, &clientStacks[i], &serverStack, buf[:]) // ACK
@@ -173,7 +173,7 @@ func TestListener_MultiConn(t *testing.T) {
 	}
 
 	// Accept all connections.
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		var err error
 		acceptedConns[i], _, err = listener.TryAccept()
 		if err != nil {
@@ -185,7 +185,7 @@ func TestListener_MultiConn(t *testing.T) {
 	}
 
 	// Verify all connections established.
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		if clientConns[i].State() != tcp.StateEstablished {
 			t.Errorf("client %d: expected StateEstablished, got %s", i, clientConns[i].State())
 		}
@@ -195,7 +195,7 @@ func TestListener_MultiConn(t *testing.T) {
 	}
 
 	// Test data exchange: client -> server.
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		msg := []byte("hello from client " + string('0'+byte(i)))
 		n, err := clientConns[i].Write(msg)
 		if err != nil {
@@ -207,12 +207,12 @@ func TestListener_MultiConn(t *testing.T) {
 	}
 
 	// Exchange data packets from all clients to server.
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		expectExchange(t, &clientStacks[i], &serverStack, buf[:])
 	}
 
 	// Read data on server side and verify.
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		expected := "hello from client " + string('0'+byte(i))
 		var readBuf [64]byte
 		n, err := acceptedConns[i].Read(readBuf[:])
@@ -225,7 +225,7 @@ func TestListener_MultiConn(t *testing.T) {
 	}
 
 	// Test data exchange: server -> client.
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		msg := []byte("reply to client " + string('0'+byte(i)))
 		n, err := acceptedConns[i].Write(msg)
 		if err != nil {
@@ -237,12 +237,12 @@ func TestListener_MultiConn(t *testing.T) {
 	}
 
 	// Exchange data packets from server to all clients.
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		expectExchange(t, &serverStack, &clientStacks[i], buf[:])
 	}
 
 	// Read responses on client side and verify.
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		expected := "reply to client " + string('0'+byte(i))
 		var readBuf [64]byte
 		n, err := clientConns[i].Read(readBuf[:])
@@ -255,7 +255,7 @@ func TestListener_MultiConn(t *testing.T) {
 	}
 
 	// Close connections, alternating between client-initiated and server-initiated.
-	for i := 0; i < numClients; i++ {
+	for i := range numClients {
 		var closer, responder *StackIP
 		var closerConn, responderConn *tcp.Conn
 		var serverClosed bool

--- a/ipv4/frame_test.go
+++ b/ipv4/frame_test.go
@@ -18,7 +18,7 @@ func TestFrame(t *testing.T) {
 	rng := rand.New(rand.NewSource(1))
 	const wantVersion = 4
 	v := new(lneto.Validator)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		// SET VALUES:
 		wantIHL := uint8(5 + rng.Intn(10))
 		wantToS := ToS(rng.Intn(4))

--- a/ipv6/definitions.go
+++ b/ipv6/definitions.go
@@ -17,7 +17,7 @@ func AppendFormatAddr(dst []byte, addr [16]byte) []byte {
 	// Find the longest run of consecutive all-zero 16-bit groups for :: compression.
 	bestStart, bestLen := 0, 0
 	curStart := -1
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		if addr[i*2] == 0 && addr[i*2+1] == 0 {
 			if curStart < 0 {
 				curStart = i

--- a/lneto_test.go
+++ b/lneto_test.go
@@ -19,7 +19,7 @@ func TestTCPMarshalUnmarshal(t *testing.T) {
 	const maxSize = 4096
 	src := make([]byte, maxSize)
 	dst := make([]byte, maxSize)
-	for i := 0; i < 512; i++ {
+	for range 512 {
 		src = gen.AppendRandomIPv4TCPPacket(src[:0], rng, tcp.Segment{
 			SEQ:     tcp.Value(rng.Int()),
 			ACK:     tcp.Value(rng.Int()),

--- a/ntp/ntp.go
+++ b/ntp/ntp.go
@@ -269,11 +269,11 @@ func (d Date) Time() (time.Time, error) {
 func CalculateSystemPrecision(nowNano func() int64, iters []int64) int8 {
 	maxIter := len(iters)
 	if nowNano == nil {
-		for i := 0; i < maxIter; i++ {
+		for i := range maxIter {
 			iters[i] = time.Now().UnixNano()
 		}
 	} else {
-		for i := 0; i < maxIter; i++ {
+		for i := range maxIter {
 			iters[i] = nowNano()
 		}
 	}

--- a/phy/phy.go
+++ b/phy/phy.go
@@ -147,7 +147,7 @@ func (phy *Device) ResetPHY() (err error) {
 	const maxPolls = 50
 	const resetTimeout = 500 * time.Millisecond // As per standard.
 	var ctl BMCR
-	for i := 0; i < maxPolls; i++ {
+	for range maxPolls {
 		time.Sleep(resetTimeout / maxPolls)
 		ctl, err = phy.BasicControl()
 		if err != nil {

--- a/tcp/control_test.go
+++ b/tcp/control_test.go
@@ -307,7 +307,7 @@ func TestPendingSegment_RetransmitAfter3DupACKs(t *testing.T) {
 	tcb.HelperInitRcv(remoteISS, remoteISS+1, wnd)
 
 	// Three duplicate ACKs against UNA must trigger retransmit state
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		dup := Segment{
 			SEQ:   remoteISS + 1,
 			ACK:   iss, // UNA (duplicate, no progress)
@@ -405,7 +405,7 @@ func TestACKLoop_MutualOutOfWindow(t *testing.T) {
 	tcbA.pending[0] = FlagACK
 
 	const maxRounds = 50
-	for round := 0; round < maxRounds; round++ {
+	for range maxRounds {
 		segA, okA := tcbA.PendingSegment(0)
 		if okA {
 			tcbA.Send(segA)

--- a/tcp/handler.go
+++ b/tcp/handler.go
@@ -431,13 +431,6 @@ func (h *Handler) IsTxOver() bool {
 		state == StateTimeWait && !h.scb.HasPending()
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func errstr(err error) string {
 	if err == nil {
 		return "<nil>"

--- a/tcp/handler_test.go
+++ b/tcp/handler_test.go
@@ -1002,7 +1002,7 @@ func TestHandler_RetransmitAfter3DupACKs(t *testing.T) {
 	if !client.scb.IncomingIsDupACK(dup.ACK) {
 		t.Fatal("MakeRetransmitDupACK return should be considered a duplicate ACK by remote")
 	}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		fb, _ := NewFrame(pkt[:])
 		fb.SetSourcePort(server.LocalPort())
 		fb.SetDestinationPort(client.LocalPort())
@@ -1083,7 +1083,7 @@ func TestHandler_RetransmitAfterMultipleLossesBothDirections(t *testing.T) {
 		if !sender.scb.IncomingIsDupACK(dup.ACK) {
 			t.Fatal("dup ACK not recognized as dupack by sender")
 		}
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			clear(pkt[:])
 			fb, _ := NewFrame(pkt[:])
 			fb.SetSourcePort(receiver.LocalPort())
@@ -1144,8 +1144,8 @@ func TestHandler_RetransmitAfterMultipleLossesBothDirections(t *testing.T) {
 	}
 
 	// Do several losses in client->server direction
-	for i := 0; i < loops; i++ {
-		payload := []byte(fmt.Sprintf("C->S loss %d", i))
+	for i := range loops {
+		payload := fmt.Appendf(nil, "C->S loss %d", i)
 		sendWithLoss(client, server, payload)
 		sendWithLoss(client, server, payload)
 		sendWithLoss(server, client, payload)

--- a/tcp/rst_test.go
+++ b/tcp/rst_test.go
@@ -86,7 +86,7 @@ func TestRSTQueue_DrainNegativeOffset(t *testing.T) {
 func TestRSTQueue_Full(t *testing.T) {
 	var q RSTQueue
 	addr := []byte{10, 0, 0, 1}
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		q.Queue(addr, uint16(i), 1234, Value(i), 0, FlagRST)
 	}
 	if q.Pending() != 4 {
@@ -143,7 +143,7 @@ func TestRSTQueue_MultipleDrains(t *testing.T) {
 	const offsetToTCP = 34
 
 	// Drain all 3 entries.
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		setIPv4Version(carrier, offsetToIP)
 		n, err := q.Drain(carrier, offsetToIP, offsetToTCP)
 		if err != nil {

--- a/tcp/syncookie.go
+++ b/tcp/syncookie.go
@@ -161,7 +161,7 @@ func (sc *SYNCookieJar) hashTuple(srcAddr, dstAddr []byte, srcPort, dstPort uint
 	// Handle remaining bytes of srcAddr
 	if rem := len(srcAddr) % 4; rem != 0 {
 		var last uint32
-		for i := 0; i < rem; i++ {
+		for i := range rem {
 			last |= uint32(srcAddr[len(srcAddr)-rem+i]) << (i * 8)
 		}
 		h3 ^= last
@@ -174,7 +174,7 @@ func (sc *SYNCookieJar) hashTuple(srcAddr, dstAddr []byte, srcPort, dstPort uint
 	// Handle remaining bytes of dstAddr
 	if rem := len(dstAddr) % 4; rem != 0 {
 		var last uint32
-		for i := 0; i < rem; i++ {
+		for i := range rem {
 			last |= uint32(dstAddr[len(dstAddr)-rem+i]) << (i * 8)
 		}
 		h0 ^= last

--- a/tcp/txqueue_test.go
+++ b/tcp/txqueue_test.go
@@ -27,9 +27,9 @@ func TestRingTx_op(t *testing.T) {
 	dataSent := make([]byte, 0, maxBuf*10)
 	var rtx ringTx
 	rng := rand.New(rand.NewSource(0))
-	for iseed := int64(0); iseed < 1000; iseed++ {
+	for iseed := range int64(1000) {
 		rng.Seed(iseed + rng.Int63())
-		for itest := 0; itest < 32; itest++ {
+		for itest := range 32 {
 			bufsize := rng.Intn(maxBuf/2) + maxBuf/2
 			iss := Value(0)
 			npackets := rng.Intn(maxpkt-1) + 1
@@ -45,7 +45,7 @@ func TestRingTx_op(t *testing.T) {
 			nacked := 0
 			dataWritten = dataWritten[:0]
 			dataSent = dataSent[:0]
-			for iop := 0; iop < Nops; iop++ {
+			for iop := range Nops {
 				free := bufsize - nsent - nunsent
 				availPkt := rtx.slist.Free()
 				op := op(rng.Intn(int(opmax)))
@@ -180,7 +180,7 @@ func TestSentlist_simple(t *testing.T) {
 
 	// Test partial ack.
 	sl.AddPacket(pkt, 0, bufsize, sl.ssn)
-	for i := Value(0); i < pkt-1; i++ {
+	for range Value(pkt - 1) {
 		ack++
 		sl.RecvAck(ack, bufsize)
 		oldest = sl.Oldest()
@@ -208,7 +208,7 @@ func TestTxQueue_multipacket(t *testing.T) {
 	internalbuff := make([]byte, mtu)
 	rng := rand.New(rand.NewSource(3))
 	var wbuf, rbuf [mtu]byte
-	for itest := 0; itest < 32; itest++ {
+	for itest := range 32 {
 		rng.Seed(int64(itest))
 		err := rtx.Reset(internalbuff, maxPkts, iss)
 		if err != nil {
@@ -217,7 +217,7 @@ func TestTxQueue_multipacket(t *testing.T) {
 		numWrites := rng.Intn(maxWrites) + 1
 		total := 0
 		woff := 0
-		for iw := 0; iw < numWrites; iw++ {
+		for range numWrites {
 			wlen := rng.Intn(maxWriteSize) + 1
 			towrite := wbuf[woff : woff+wlen]
 			rng.Read(towrite)
@@ -234,7 +234,7 @@ func TestTxQueue_multipacket(t *testing.T) {
 		npkt := rng.Intn(maxPkts) + 1
 		roff := 0
 		seq := Value(iss)
-		for ipkt := 0; ipkt < npkt; ipkt++ {
+		for range npkt {
 			maxToPacket := min(total-roff, maxWriteSize)
 			pktlen := rng.Intn(maxToPacket) + 1
 			pkt := rbuf[roff : roff+pktlen]
@@ -289,7 +289,7 @@ func TestTxQueue(t *testing.T) {
 			name: "SequentialMessages",
 			test: func(t *testing.T) {
 				const startAck = 0
-				for i := 0; i < 10; i++ {
+				for range 10 {
 					rng.Read(msgBuf[:])
 					msgs := removeEmptyMsgs(bytes.SplitAfter(msgBuf[:], []byte{0}))
 					currentAck := Value(startAck)
@@ -314,7 +314,7 @@ func TestTxQueue(t *testing.T) {
 			name: "N-Messages",
 			test: func(t *testing.T) {
 				const startAck = 0
-				for i := 0; i < 10; i++ {
+				for range 10 {
 					rng.Read(msgBuf[:])
 					msgs := removeEmptyMsgs(bytes.SplitAfter(msgBuf[:], []byte{0}))
 					currentAck := Value(startAck)
@@ -362,7 +362,7 @@ func TestTxQueue(t *testing.T) {
 				const packets = 100
 				const maxPacketSize = bufsize / 4
 				var datalens [][]byte
-				for i := 0; i < 10; i++ {
+				for range 10 {
 					rng.Read(msgBuf[:])
 					err := rtx.Reset(ringBuf[:], packets, startAck)
 					if err != nil {

--- a/udp/conn_test.go
+++ b/udp/conn_test.go
@@ -163,7 +163,7 @@ func TestConn_ReadTruncates(t *testing.T) {
 
 func TestConn_DemuxExhausted(t *testing.T) {
 	conn := newTestConn(t) // queue size 4
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		frame := makeUDPFrame(8080, 1234, []byte{byte(i)})
 		err := conn.Demux(frame, 0)
 		if err != nil {

--- a/x/xnet/stack-berkeley.go
+++ b/x/xnet/stack-berkeley.go
@@ -31,7 +31,7 @@ const (
 // family must be syscall.AF_INET. SOCK_STREAM is only one supported for now since is TCP.
 // network supported for now is "tcp" or "tcp4". A nil remote address and defined local address means net.Listener is returned.
 // if remote address defined then is active connection, returns a net.Conn.
-type gosocket = func(ctx context.Context, network string, family, sotype int, laddr, raddr net.Addr) (c interface{}, err error)
+type gosocket = func(ctx context.Context, network string, family, sotype int, laddr, raddr net.Addr) (c any, err error)
 
 type socket[T any] struct {
 	sockfd int
@@ -84,7 +84,7 @@ func (s *StackBerkeley) Bind(sockfd int, ip netip.AddrPort) error {
 }
 
 // SetSockOpt sets a socket option on sockfd. Currently unimplemented.
-func (s *StackBerkeley) SetSockOpt(sockfd int, level int, opt int, value interface{}) error {
+func (s *StackBerkeley) SetSockOpt(sockfd int, level int, opt int, value any) error {
 	return nil
 }
 

--- a/x/xnet/stack-blocking.go
+++ b/x/xnet/stack-blocking.go
@@ -41,7 +41,7 @@ func (s StackBlocking) DoDHCPv4(reqAddr [4]byte, timeout time.Duration) (*DHCPRe
 	deadline := time.Now().Add(timeout)
 	requested := false
 	var lastState dhcpv4.ClientState
-	for i := 0; i < maxIter; i++ {
+	for range maxIter {
 		s.async.mu.Lock()
 		state := s.async.dhcp.State()
 		s.async.mu.Unlock()
@@ -80,7 +80,7 @@ func (s StackBlocking) DoPing(hostAddr netip.Addr, timeout time.Duration) (round
 	}
 	start := time.Now()
 	var backoffs uint
-	for i := 0; i < maxIter; i++ {
+	for range maxIter {
 		s.async.mu.Lock()
 		completed, exists := s.async.icmp.PingPop(key)
 		s.async.mu.Unlock()
@@ -108,7 +108,7 @@ func (s StackBlocking) DoNTP(hostAddr netip.Addr, timeout time.Duration) (offset
 	deadline := time.Now().Add(timeout)
 	var done bool
 	var backoffs uint
-	for i := 0; i < maxIter; i++ {
+	for range maxIter {
 		offset, done = s.async.ResultNTPOffset()
 		if done {
 			return offset, nil
@@ -128,7 +128,7 @@ func (s StackBlocking) DoResolveHardwareAddress6(addr netip.Addr, timeout time.D
 	}
 	var backoffs uint
 	deadline := time.Now().Add(timeout)
-	for i := 0; i < maxIter; i++ {
+	for range maxIter {
 		hw, err = s.async.ResultResolveHardwareAddress6(addr)
 		if err == nil {
 			break
@@ -152,7 +152,7 @@ func (s StackBlocking) DoLookupIP(host string, timeout time.Duration) (addrs []n
 
 	deadline := time.Now().Add(timeout)
 	var backoffs uint
-	for i := 0; i < maxIter; i++ {
+	for range maxIter {
 		addrs, completed, err := s.async.ResultLookupIP(host)
 		if completed {
 			return addrs, err
@@ -174,7 +174,7 @@ func (s StackBlocking) DoDialTCP(conn *tcp.Conn, localPort uint16, addrp netip.A
 	}
 	deadline := time.Now().Add(timeout)
 	var backoffs uint
-	for i := 0; i < maxIter; i++ {
+	for range maxIter {
 		state := conn.State()
 		if state == tcp.StateEstablished {
 			return nil

--- a/x/xnet/stack-go.go
+++ b/x/xnet/stack-go.go
@@ -38,7 +38,7 @@ type StackGo struct {
 	plcfg TCPPoolConfig
 }
 
-func (s StackGo) Socket(ctx context.Context, network string, family, sotype int, laddr, raddr net.Addr) (c interface{}, err error) {
+func (s StackGo) Socket(ctx context.Context, network string, family, sotype int, laddr, raddr net.Addr) (c any, err error) {
 	switch family {
 	case syscall.AF_INET:
 	default:
@@ -60,7 +60,7 @@ func (s StackGo) Socket(ctx context.Context, network string, family, sotype int,
 	return s.SocketNetip(ctx, network, family, sotype, local, remote)
 }
 
-func (s StackGo) SocketNetip(ctx context.Context, network string, family, sotype int, laddr, raddr netip.AddrPort) (c interface{}, err error) {
+func (s StackGo) SocketNetip(ctx context.Context, network string, family, sotype int, laddr, raddr netip.AddrPort) (c any, err error) {
 	switch family {
 	case syscall.AF_INET:
 	default:

--- a/x/xnet/stack-retrying.go
+++ b/x/xnet/stack-retrying.go
@@ -25,7 +25,7 @@ type StackRetrying struct {
 
 func (s StackRetrying) DoDHCPv4(reqAddr [4]byte, timeout time.Duration, retries int) (results *DHCPResults, err error) {
 	expectEnd := time.Now().Add(timeout * time.Duration(retries))
-	for i := 0; i < retries; i++ {
+	for i := range retries {
 		if i > 0 {
 			println("Retrying DHCP")
 		}
@@ -42,7 +42,7 @@ func (s StackRetrying) DoDHCPv4(reqAddr [4]byte, timeout time.Duration, retries 
 
 func (s StackRetrying) DoNTP(ntpHost netip.Addr, timeout time.Duration, retries int) (offset time.Duration, err error) {
 	expectEnd := time.Now().Add(timeout * time.Duration(retries))
-	for i := 0; i < retries; i++ {
+	for i := range retries {
 		if i > 0 {
 			println("Retrying NTP")
 		}
@@ -61,7 +61,7 @@ func (s StackRetrying) DoLookupIP(host string, timeout time.Duration, retries in
 		return nil, errNoDNSServer
 	}
 	expectEnd := time.Now().Add(timeout * time.Duration(retries))
-	for i := 0; i < retries; i++ {
+	for range retries {
 		addrs, err = s.block.DoLookupIP(host, timeout)
 		if err == nil {
 			return addrs, nil
@@ -75,7 +75,7 @@ func (s StackRetrying) DoLookupIP(host string, timeout time.Duration, retries in
 
 func (s StackRetrying) DoResolveHardwareAddress6(addr netip.Addr, timeout time.Duration, retries int) (hw [6]byte, err error) {
 	expectEnd := time.Now().Add(timeout * time.Duration(retries))
-	for i := 0; i < retries; i++ {
+	for range retries {
 		hw, err = s.block.DoResolveHardwareAddress6(addr, timeout)
 		if err == nil {
 			return hw, nil
@@ -90,7 +90,7 @@ func (s StackRetrying) DoResolveHardwareAddress6(addr netip.Addr, timeout time.D
 func (s StackRetrying) DoDialTCP(conn *tcp.Conn, localPort uint16, addrp netip.AddrPort, timeout time.Duration, retries int) (err error) {
 	expectEnd := time.Now().Add(timeout * time.Duration(retries))
 	var firstErr error
-	for i := 0; i < retries; i++ {
+	for range retries {
 		err = s.block.DoDialTCP(conn, localPort, addrp, timeout)
 		if err == nil {
 			return nil

--- a/x/xnet/xnet_concurrent_test.go
+++ b/x/xnet/xnet_concurrent_test.go
@@ -259,7 +259,7 @@ func runClient(t *testing.T, id int, stack *StackAsync, conn *tcp.Conn,
 	}
 
 	// Send test data.
-	testData := []byte(fmt.Sprintf("hello from client %d", id))
+	testData := fmt.Appendf(nil, "hello from client %d", id)
 	_, err = conn.Write(testData)
 	if err != nil {
 		t.Errorf("client %d write failed: %v", id, err)

--- a/x/xnet/xnet_dns_test.go
+++ b/x/xnet/xnet_dns_test.go
@@ -3,6 +3,7 @@ package xnet
 import (
 	"errors"
 	"net/netip"
+	"slices"
 	"testing"
 
 	"github.com/soypat/lneto"
@@ -87,13 +88,7 @@ func TestDNS_QueryReceivesAnswer(t *testing.T) {
 		t.Fatal("no addresses returned from DNS lookup")
 	}
 
-	found := false
-	for _, addr := range addrs {
-		if addr == wantAddr {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(addrs, wantAddr)
 	if !found {
 		t.Errorf("expected address %s not found in result %v", wantAddr, addrs)
 	}

--- a/x/xnet/xnet_fuzz_test.go
+++ b/x/xnet/xnet_fuzz_test.go
@@ -532,7 +532,7 @@ func testStackSeeded(t *testing.T, seed1, seed2 int64) {
 		// Hard ceiling prevents infinite send loops from passing silently.
 		// Also send drained packet to other stack to also catch infinite feedback loops.
 		const drainLimit = 8
-		for d := 0; d < drainLimit; d++ {
+		for d := range drainLimit {
 			limit := d == drainLimit-1
 			n, err := first.EgressEthernet(buf[:])
 			if (err != nil || n > 0) && limit {

--- a/x/xnet/xnet_test.go
+++ b/x/xnet/xnet_test.go
@@ -127,7 +127,7 @@ func TestStackAsyncTCP_multipacket(t *testing.T) {
 		tst.TestTCPSetupAndEstablish(sv, client, svconn, clconn, svPort, 1337)
 		testClose()
 		var buf [MTU]byte
-		for i := 0; i < 20; i++ {
+		for range 20 {
 			payloadSize := rng.Intn(maxPktLen) + 1
 			tst.TestTCPSetupAndEstablish(sv, client, svconn, clconn, svPort, 1337)
 			// npkt := rng.Intn(maxNPkt-1) + 2


### PR DESCRIPTION
I updated to 1.25 (currently 1.26 is stable but 1.25 is more widely available I suppose). As newer Go version simplified some syntax I simply ran `go fix -newexpr ./...` which will call the go modernize tool. Hence all the code changes have been done directly by the go tool and not manually. I'm not too sure which version tinygo is still compatible with as I'm not so familiar with that toolchain. 