### PR TITLE
Retransmit active-open SYN after RTO

### DIFF
--- a/tcp/conn.go
+++ b/tcp/conn.go
@@ -90,6 +90,22 @@ func (conn *Conn) RemotePort() uint16 {
 	return conn.h.RemotePort()
 }
 
+// IsAwaitingControl reports whether the connection is waiting for a response to
+// a control segment that can be retransmitted to advance connection state.
+func (conn *Conn) IsAwaitingControl() bool {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	return conn.h.IsAwaitingControl()
+}
+
+// RequeueControl asks the next packet emission to retransmit the outstanding
+// control segment, if the connection is waiting for one.
+func (conn *Conn) RequeueControl() {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	conn.h.RequeueControl()
+}
+
 func (conn *Conn) RemoteAddr() []byte {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()

--- a/tcp/handler.go
+++ b/tcp/handler.go
@@ -3,6 +3,7 @@ package tcp
 import (
 	"io"
 	"net"
+	"time"
 
 	"log/slog"
 
@@ -33,7 +34,16 @@ type Handler struct {
 	shutdownRx bool
 	// nRetransmit stores the number of times the oldest packet was retransmit.
 	nRetransmit uint8
+	// synLastTx and synRTO track active-open SYN retransmission while waiting
+	// for the remote SYN-ACK. They are reset with each new connection.
+	synLastTx time.Time
+	synRTO    time.Duration
 }
+
+const (
+	initialSynRTO = time.Second
+	maxSynRTO     = 4 * time.Second
+)
 
 func (h *Handler) SetLoggers(handler, scb *slog.Logger) {
 	h.logger.log = handler
@@ -256,6 +266,8 @@ func (h *Handler) Send(b []byte) (int, error) {
 		return 0, net.ErrClosed
 	}
 	awaitingSyn := h.AwaitingSynSend()
+	now := time.Now()
+	retransmitSyn := !awaitingSyn && h.shouldRetransmitSyn(now)
 	buffered := h.bufTx.BufferedUnsent()
 	if h.scb.State() == StateCloseWait && !h.closing && buffered == 0 && !h.scb.HasPending() {
 		// Remote closed with no application data left to send: initiate our own close.
@@ -263,7 +275,7 @@ func (h *Handler) Send(b []byte) (int, error) {
 		// before Send is called, implementing the half-close per RFC 9293 §3.5.
 		h.closing = true
 	}
-	if !awaitingSyn && buffered == 0 && !h.closing && !h.scb.HasPending() {
+	if !awaitingSyn && !retransmitSyn && buffered == 0 && !h.closing && !h.scb.HasPending() {
 		// Early nop short circuit.
 		return 0, nil
 	}
@@ -286,11 +298,14 @@ func (h *Handler) Send(b []byte) (int, error) {
 	offset := uint8(5)
 	mss := uint16(len(b) - sizeHeaderTCP)
 	var segment Segment
-	if awaitingSyn {
+	if awaitingSyn || retransmitSyn {
 		// Handling init syn segment.
 		segment = ClientSynSegment(h.bufTx.iss, Size(h.bufRx.Size()))
 		h.optcodec.PutOption16(b[sizeHeaderTCP:], OptMaxSegmentSize, mss)
 		offset++
+		if retransmitSyn {
+			h.info("tcp.Handler:retransmit-syn", slog.Uint64("port", uint64(h.localPort)), slog.Uint64("rport", uint64(h.remotePort)))
+		}
 	} else {
 		var ok bool
 		maxPayload := len(b) - sizeHeaderTCP
@@ -320,6 +335,9 @@ func (h *Handler) Send(b []byte) (int, error) {
 	} else if prevState != h.scb.State() && h.logenabled(slog.LevelInfo) {
 		h.info("tcp.Handler:tx-statechange", slog.Uint64("port", uint64(h.localPort)), slog.String("oldState", prevState.String()), slog.String("newState", h.scb.State().String()), slog.String("txflags", segment.Flags.String()))
 	}
+	if segment.Flags == FlagSYN && h.scb.State() == StateSynSent {
+		h.markSynSent(now)
+	}
 	tfrm.SetSourcePort(h.localPort)
 	tfrm.SetDestinationPort(h.remotePort)
 	tfrm.SetSegment(segment, offset)
@@ -330,6 +348,22 @@ func (h *Handler) Send(b []byte) (int, error) {
 		h.reset(0, 0, 0)
 	}
 	return datalen, nil
+}
+
+func (h *Handler) shouldRetransmitSyn(now time.Time) bool {
+	return h.AwaitingSynResponse() && !h.synLastTx.IsZero() && !now.Before(h.synLastTx.Add(h.synRTO))
+}
+
+func (h *Handler) markSynSent(now time.Time) {
+	h.synLastTx = now
+	if h.synRTO == 0 {
+		h.synRTO = initialSynRTO
+		return
+	}
+	h.synRTO *= 2
+	if h.synRTO > maxSynRTO {
+		h.synRTO = maxSynRTO
+	}
 }
 
 // Write implements [io.Writer] by copying b to a internal buffer to be sent over the network on the next

--- a/tcp/handler.go
+++ b/tcp/handler.go
@@ -3,7 +3,6 @@ package tcp
 import (
 	"io"
 	"net"
-	"time"
 
 	"log/slog"
 
@@ -33,17 +32,9 @@ type Handler struct {
 	closing    bool
 	shutdownRx bool
 	// nRetransmit stores the number of times the oldest packet was retransmit.
-	nRetransmit uint8
-	// synLastTx and synRTO track active-open SYN retransmission while waiting
-	// for the remote SYN-ACK. They are reset with each new connection.
-	synLastTx time.Time
-	synRTO    time.Duration
+	nRetransmit    uint8
+	requeueControl bool
 }
-
-const (
-	initialSynRTO = time.Second
-	maxSynRTO     = 4 * time.Second
-)
 
 func (h *Handler) SetLoggers(handler, scb *slog.Logger) {
 	h.logger.log = handler
@@ -266,8 +257,7 @@ func (h *Handler) Send(b []byte) (int, error) {
 		return 0, net.ErrClosed
 	}
 	awaitingSyn := h.AwaitingSynSend()
-	now := time.Now()
-	retransmitSyn := !awaitingSyn && h.shouldRetransmitSyn(now)
+	requeueControl := h.requeueControl
 	buffered := h.bufTx.BufferedUnsent()
 	if h.scb.State() == StateCloseWait && !h.closing && buffered == 0 && !h.scb.HasPending() {
 		// Remote closed with no application data left to send: initiate our own close.
@@ -275,7 +265,7 @@ func (h *Handler) Send(b []byte) (int, error) {
 		// before Send is called, implementing the half-close per RFC 9293 §3.5.
 		h.closing = true
 	}
-	if !awaitingSyn && !retransmitSyn && buffered == 0 && !h.closing && !h.scb.HasPending() {
+	if !awaitingSyn && !requeueControl && buffered == 0 && !h.closing && !h.scb.HasPending() {
 		// Early nop short circuit.
 		return 0, nil
 	}
@@ -298,14 +288,27 @@ func (h *Handler) Send(b []byte) (int, error) {
 	offset := uint8(5)
 	mss := uint16(len(b) - sizeHeaderTCP)
 	var segment Segment
-	if awaitingSyn || retransmitSyn {
+	if awaitingSyn || requeueControl && h.scb.State() == StateSynSent {
 		// Handling init syn segment.
 		segment = ClientSynSegment(h.bufTx.iss, Size(h.bufRx.Size()))
 		h.optcodec.PutOption16(b[sizeHeaderTCP:], OptMaxSegmentSize, mss)
 		offset++
-		if retransmitSyn {
-			h.info("tcp.Handler:retransmit-syn", slog.Uint64("port", uint64(h.localPort)), slog.Uint64("rport", uint64(h.remotePort)))
+		if requeueControl {
+			h.info("tcp.Handler:requeue-syn", slog.Uint64("port", uint64(h.localPort)), slog.Uint64("rport", uint64(h.remotePort)))
 		}
+	} else if requeueControl && h.scb.State() == StateSynRcvd {
+		segment = Segment{
+			SEQ:   h.scb.snd.UNA,
+			ACK:   h.scb.rcv.NXT,
+			WND:   Size(h.bufRx.Free()),
+			Flags: synack,
+		}
+		h.optcodec.PutOption16(b[sizeHeaderTCP:], OptMaxSegmentSize, mss)
+		offset++
+		h.info("tcp.Handler:requeue-synack", slog.Uint64("port", uint64(h.localPort)), slog.Uint64("rport", uint64(h.remotePort)))
+	} else if requeueControl {
+		h.requeueControl = false
+		return 0, nil
 	} else {
 		var ok bool
 		maxPayload := len(b) - sizeHeaderTCP
@@ -335,9 +338,7 @@ func (h *Handler) Send(b []byte) (int, error) {
 	} else if prevState != h.scb.State() && h.logenabled(slog.LevelInfo) {
 		h.info("tcp.Handler:tx-statechange", slog.Uint64("port", uint64(h.localPort)), slog.String("oldState", prevState.String()), slog.String("newState", h.scb.State().String()), slog.String("txflags", segment.Flags.String()))
 	}
-	if segment.Flags == FlagSYN && h.scb.State() == StateSynSent {
-		h.markSynSent(now)
-	}
+	h.requeueControl = false
 	tfrm.SetSourcePort(h.localPort)
 	tfrm.SetDestinationPort(h.remotePort)
 	tfrm.SetSegment(segment, offset)
@@ -348,22 +349,6 @@ func (h *Handler) Send(b []byte) (int, error) {
 		h.reset(0, 0, 0)
 	}
 	return datalen, nil
-}
-
-func (h *Handler) shouldRetransmitSyn(now time.Time) bool {
-	return h.AwaitingSynResponse() && !h.synLastTx.IsZero() && !now.Before(h.synLastTx.Add(h.synRTO))
-}
-
-func (h *Handler) markSynSent(now time.Time) {
-	h.synLastTx = now
-	if h.synRTO == 0 {
-		h.synRTO = initialSynRTO
-		return
-	}
-	h.synRTO *= 2
-	if h.synRTO > maxSynRTO {
-		h.synRTO = maxSynRTO
-	}
 }
 
 // Write implements [io.Writer] by copying b to a internal buffer to be sent over the network on the next
@@ -456,6 +441,20 @@ func (h *Handler) FreeInput() int {
 // AwaitingSynResponse returns true if the Handler is an active client opened with [Handler.OpenActive] and has already sent out the first SYN packet to the remote client.
 func (h *Handler) AwaitingSynResponse() bool {
 	return h.remotePort != 0 && h.scb.State() == StateSynSent
+}
+
+// IsAwaitingControl reports whether the connection is waiting for a response to
+// a control segment that can be retransmitted to advance connection state.
+func (h *Handler) IsAwaitingControl() bool {
+	return h.AwaitingSynResponse() || h.scb.State() == StateSynRcvd
+}
+
+// RequeueControl asks the next Send call to retransmit the outstanding control
+// segment, if the connection is waiting for one.
+func (h *Handler) RequeueControl() {
+	if h.IsAwaitingControl() {
+		h.requeueControl = true
+	}
 }
 
 // AwaitingSynAck returns true if the Handler is a passive server opened with [Handler.OpenListen] and not yet received a valid SYN remote packet.

--- a/tcp/handler_test.go
+++ b/tcp/handler_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/soypat/lneto/ethernet"
 )
@@ -21,7 +20,7 @@ func TestHandler(t *testing.T) {
 	sendDataFull(t, client, server, []byte("hello"), rawbuf[:])
 }
 
-func TestHandler_RetransmitSYNAfterRTO(t *testing.T) {
+func TestHandler_RequeueControlRetransmitsSYN(t *testing.T) {
 	const mtu = ethernet.MaxMTU
 	const maxpackets = 3
 	rng := rand.New(rand.NewSource(1))
@@ -46,12 +45,12 @@ func TestHandler_RetransmitSYNAfterRTO(t *testing.T) {
 	clear(rawbuf[:])
 	n, err = client.Send(rawbuf[:])
 	if err != nil {
-		t.Fatal("client sending before SYN RTO:", err)
+		t.Fatal("client sending before RequeueControl:", err)
 	} else if n != 0 {
-		t.Fatalf("Send before SYN RTO wrote %d bytes, want 0", n)
+		t.Fatalf("Send before RequeueControl wrote %d bytes, want 0", n)
 	}
 
-	client.synLastTx = time.Now().Add(-client.synRTO)
+	client.RequeueControl()
 	clear(rawbuf[:])
 	n, err = client.Send(rawbuf[:])
 	if err != nil {
@@ -98,7 +97,7 @@ func TestHandler_RetransmitSYNAfterRTO(t *testing.T) {
 		t.Fatal("server receiving final ACK:", err)
 	}
 
-	client.synLastTx = time.Now().Add(-maxSynRTO)
+	client.RequeueControl()
 	clear(rawbuf[:])
 	n, err = client.Send(rawbuf[:])
 	if err != nil {

--- a/tcp/handler_test.go
+++ b/tcp/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/soypat/lneto/ethernet"
 )
@@ -18,6 +19,103 @@ func TestHandler(t *testing.T) {
 	var rawbuf [mtu]byte
 	establish(t, client, server, rawbuf[:])
 	sendDataFull(t, client, server, []byte("hello"), rawbuf[:])
+}
+
+func TestHandler_RetransmitSYNAfterRTO(t *testing.T) {
+	const mtu = ethernet.MaxMTU
+	const maxpackets = 3
+	rng := rand.New(rand.NewSource(1))
+	client, server := newHandler(t, mtu, maxpackets), newHandler(t, mtu, maxpackets)
+	setupClientServer(t, rng, client, server)
+
+	var rawbuf [mtu]byte
+	n, err := client.Send(rawbuf[:])
+	if err != nil {
+		t.Fatal("client sending initial SYN:", err)
+	} else if n < sizeHeaderTCP {
+		t.Fatalf("initial SYN size=%d, want at least %d", n, sizeHeaderTCP)
+	}
+	initial := mustSegment(t, rawbuf[:n], 0)
+	if initial.Flags != FlagSYN {
+		t.Fatalf("initial flags=%s, want SYN", initial.Flags)
+	}
+	if client.State() != StateSynSent {
+		t.Fatalf("client state=%s, want SYN-SENT", client.State())
+	}
+
+	clear(rawbuf[:])
+	n, err = client.Send(rawbuf[:])
+	if err != nil {
+		t.Fatal("client sending before SYN RTO:", err)
+	} else if n != 0 {
+		t.Fatalf("Send before SYN RTO wrote %d bytes, want 0", n)
+	}
+
+	client.synLastTx = time.Now().Add(-client.synRTO)
+	clear(rawbuf[:])
+	n, err = client.Send(rawbuf[:])
+	if err != nil {
+		t.Fatal("client retransmitting SYN:", err)
+	} else if n < sizeHeaderTCP {
+		t.Fatalf("retransmitted SYN size=%d, want at least %d", n, sizeHeaderTCP)
+	}
+	retransmit := mustSegment(t, rawbuf[:n], 0)
+	if retransmit.Flags != FlagSYN {
+		t.Fatalf("retransmit flags=%s, want SYN", retransmit.Flags)
+	}
+	if retransmit.SEQ != initial.SEQ {
+		t.Fatalf("retransmit SEQ=%d, want initial SEQ=%d", retransmit.SEQ, initial.SEQ)
+	}
+
+	if err := server.Recv(rawbuf[:n]); err != nil {
+		t.Fatal("server receiving retransmitted SYN:", err)
+	}
+	clear(rawbuf[:])
+	n, err = server.Send(rawbuf[:])
+	if err != nil {
+		t.Fatal("server sending SYN-ACK:", err)
+	}
+	segSynAck := mustSegment(t, rawbuf[:n], 0)
+	if segSynAck.Flags != synack {
+		t.Fatalf("server flags=%s, want SYN-ACK", segSynAck.Flags)
+	}
+	if err := client.Recv(rawbuf[:n]); err != nil {
+		t.Fatal("client receiving SYN-ACK:", err)
+	}
+	if client.State() != StateEstablished {
+		t.Fatalf("client state=%s, want ESTABLISHED", client.State())
+	}
+
+	clear(rawbuf[:])
+	n, err = client.Send(rawbuf[:]) // final ACK.
+	if err != nil {
+		t.Fatal("client sending final ACK:", err)
+	}
+	if ack := mustSegment(t, rawbuf[:n], 0); ack.Flags != FlagACK {
+		t.Fatalf("client final flags=%s, want ACK", ack.Flags)
+	}
+	if err := server.Recv(rawbuf[:n]); err != nil {
+		t.Fatal("server receiving final ACK:", err)
+	}
+
+	client.synLastTx = time.Now().Add(-maxSynRTO)
+	clear(rawbuf[:])
+	n, err = client.Send(rawbuf[:])
+	if err != nil {
+		t.Fatal("client sending after establishment:", err)
+	} else if n != 0 {
+		seg := mustSegment(t, rawbuf[:n], 0)
+		t.Fatalf("Send after establishment wrote %d bytes (%s), want 0", n, seg.Flags)
+	}
+}
+
+func mustSegment(t *testing.T, b []byte, payloadLen int) Segment {
+	t.Helper()
+	frame, err := NewFrame(b)
+	if err != nil {
+		t.Fatal("parse TCP frame:", err)
+	}
+	return frame.Segment(payloadLen)
 }
 
 func sendDataFull(t *testing.T, client, server *Handler, data, packetBuf []byte) {

--- a/x/xnet/stack-blocking.go
+++ b/x/xnet/stack-blocking.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	maxIter              = 1000
-	controlRetryInterval = time.Second
+	maxIter = 1000
 )
 
 var (
@@ -182,8 +181,15 @@ func (s StackBlocking) DoDialTCP(conn *tcp.Conn, localPort uint16, addrp netip.A
 	if err != nil {
 		return err
 	}
+	err = s.waitDialTCP(conn, timeout)
+	if err != nil {
+		conn.Abort()
+	}
+	return err
+}
+
+func (s StackBlocking) waitDialTCP(conn *tcp.Conn, timeout time.Duration) (err error) {
 	deadline := time.Now().Add(timeout)
-	controlRetryAt := time.Now().Add(controlRetryInterval)
 	var backoffs uint
 	for range maxIter {
 		state := conn.State()
@@ -191,16 +197,10 @@ func (s StackBlocking) DoDialTCP(conn *tcp.Conn, localPort uint16, addrp netip.A
 			return nil
 		} else if state == tcp.StateSynSent || state == tcp.StateSynRcvd || conn.AwaitingSynSend() {
 			if err = s.checkDeadline(deadline); err != nil {
-				conn.Abort()
 				return err
-			}
-			if conn.IsAwaitingControl() && time.Since(controlRetryAt) >= 0 {
-				conn.RequeueControl()
-				controlRetryAt = time.Now().Add(controlRetryInterval)
 			}
 		} else {
 			// Unexpected state, abort and terminate connection.
-			conn.Abort()
 			return errTCPFailedToConnect
 		}
 		s.backoff(backoffs)

--- a/x/xnet/stack-blocking.go
+++ b/x/xnet/stack-blocking.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	maxIter = 1000
+	maxIter              = 1000
+	controlRetryInterval = time.Second
 )
 
 var (
@@ -182,6 +183,7 @@ func (s StackBlocking) DoDialTCP(conn *tcp.Conn, localPort uint16, addrp netip.A
 		return err
 	}
 	deadline := time.Now().Add(timeout)
+	controlRetryAt := time.Now().Add(controlRetryInterval)
 	var backoffs uint
 	for range maxIter {
 		state := conn.State()
@@ -191,6 +193,10 @@ func (s StackBlocking) DoDialTCP(conn *tcp.Conn, localPort uint16, addrp netip.A
 			if err = s.checkDeadline(deadline); err != nil {
 				conn.Abort()
 				return err
+			}
+			if conn.IsAwaitingControl() && time.Since(controlRetryAt) >= 0 {
+				conn.RequeueControl()
+				controlRetryAt = time.Now().Add(controlRetryInterval)
 			}
 		} else {
 			// Unexpected state, abort and terminate connection.

--- a/x/xnet/stack-go.go
+++ b/x/xnet/stack-go.go
@@ -175,7 +175,6 @@ func (s StackGo) SocketNetip(ctx context.Context, network string, family, sotype
 			if err != nil {
 				return nil, err
 			}
-			controlRetryAt := time.Now().Add(controlRetryInterval)
 			var backoffs uint
 			for {
 				s.blk.backoff(backoffs)
@@ -191,10 +190,6 @@ func (s StackGo) SocketNetip(ctx context.Context, network string, family, sotype
 					if err = ctx.Err(); err != nil {
 						conn.Abort()
 						return nil, err
-					}
-					if conn.IsAwaitingControl() && time.Since(controlRetryAt) >= 0 {
-						conn.RequeueControl()
-						controlRetryAt = time.Now().Add(controlRetryInterval)
 					}
 				} else {
 					// Unexpected state, abort and terminate connection.

--- a/x/xnet/stack-go.go
+++ b/x/xnet/stack-go.go
@@ -22,6 +22,8 @@ const (
 
 type StackGoConfig struct {
 	ListenerPoolConfig TCPPoolConfig
+	TCPDialTimeout     time.Duration
+	TCPDialRetries     int
 }
 
 func (s *StackAsync) StackGo(stackProtoBackoff lneto.BackoffStrategy, cfg StackGoConfig) StackGo {
@@ -33,15 +35,19 @@ func (s *StackAsync) StackGo(stackProtoBackoff lneto.BackoffStrategy, cfg StackG
 
 func (s StackBlocking) StackGo(cfg StackGoConfig) StackGo {
 	sg := StackGo{
-		blk:   s,
-		plcfg: cfg.ListenerPoolConfig,
+		blk:            s,
+		plcfg:          cfg.ListenerPoolConfig,
+		tcpDialTimeout: cfg.TCPDialTimeout,
+		tcpDialRetries: cfg.TCPDialRetries,
 	}
 	return sg
 }
 
 type StackGo struct {
-	blk   StackBlocking
-	plcfg TCPPoolConfig
+	blk            StackBlocking
+	plcfg          TCPPoolConfig
+	tcpDialTimeout time.Duration
+	tcpDialRetries int
 }
 
 func (s StackGo) Socket(ctx context.Context, network string, family, sotype int, laddr, raddr net.Addr) (c any, err error) {
@@ -171,9 +177,16 @@ func (s StackGo) SocketNetip(ctx context.Context, network string, family, sotype
 			if err != nil {
 				return nil, err
 			}
-			err = s.blk.async.DialTCP(&conn, laddr.Port(), raddr)
-			if err != nil {
-				return nil, err
+			if s.tcpDialRetries > 0 && s.tcpDialTimeout > 0 {
+				err = (StackRetrying{block: s.blk}).DoDialTCP(&conn, laddr.Port(), raddr, s.tcpDialTimeout, s.tcpDialRetries)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				err = s.blk.async.DialTCP(&conn, laddr.Port(), raddr)
+				if err != nil {
+					return nil, err
+				}
 			}
 			var backoffs uint
 			for {

--- a/x/xnet/stack-go.go
+++ b/x/xnet/stack-go.go
@@ -18,6 +18,9 @@ import (
 const (
 	sockSTREAM = 0x1
 	sockDGRAM  = 0x2
+
+	defaultTCPDialTimeout = 2 * time.Second
+	defaultTCPDialRetries = 1
 )
 
 type StackGoConfig struct {
@@ -34,11 +37,23 @@ func (s *StackAsync) StackGo(stackProtoBackoff lneto.BackoffStrategy, cfg StackG
 }
 
 func (s StackBlocking) StackGo(cfg StackGoConfig) StackGo {
+	tcpDialTimeout := cfg.TCPDialTimeout
+	tcpDialRetries := cfg.TCPDialRetries
+
+
+	//defaults
+	if tcpDialTimeout <= 0 {
+		tcpDialTimeout = defaultTCPDialTimeout
+	}
+	if tcpDialRetries <= 0 {
+		tcpDialRetries = defaultTCPDialRetries
+	}
+
 	sg := StackGo{
 		blk:            s,
 		plcfg:          cfg.ListenerPoolConfig,
-		tcpDialTimeout: cfg.TCPDialTimeout,
-		tcpDialRetries: cfg.TCPDialRetries,
+		tcpDialTimeout: tcpDialTimeout,
+		tcpDialRetries: tcpDialRetries,
 	}
 	return sg
 }
@@ -177,16 +192,9 @@ func (s StackGo) SocketNetip(ctx context.Context, network string, family, sotype
 			if err != nil {
 				return nil, err
 			}
-			if s.tcpDialRetries > 0 && s.tcpDialTimeout > 0 {
-				err = (StackRetrying{block: s.blk}).DoDialTCP(&conn, laddr.Port(), raddr, s.tcpDialTimeout, s.tcpDialRetries)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				err = s.blk.async.DialTCP(&conn, laddr.Port(), raddr)
-				if err != nil {
-					return nil, err
-				}
+			err = s.blk.StackRetrying().DoDialTCP(&conn, laddr.Port(), raddr, s.tcpDialTimeout, s.tcpDialRetries)
+			if err != nil {
+				return nil, err
 			}
 			var backoffs uint
 			for {

--- a/x/xnet/stack-go.go
+++ b/x/xnet/stack-go.go
@@ -39,9 +39,7 @@ func (s *StackAsync) StackGo(stackProtoBackoff lneto.BackoffStrategy, cfg StackG
 func (s StackBlocking) StackGo(cfg StackGoConfig) StackGo {
 	tcpDialTimeout := cfg.TCPDialTimeout
 	tcpDialRetries := cfg.TCPDialRetries
-
-
-	//defaults
+	// Defaults
 	if tcpDialTimeout <= 0 {
 		tcpDialTimeout = defaultTCPDialTimeout
 	}

--- a/x/xnet/stack-go.go
+++ b/x/xnet/stack-go.go
@@ -175,6 +175,7 @@ func (s StackGo) SocketNetip(ctx context.Context, network string, family, sotype
 			if err != nil {
 				return nil, err
 			}
+			controlRetryAt := time.Now().Add(controlRetryInterval)
 			var backoffs uint
 			for {
 				s.blk.backoff(backoffs)
@@ -190,6 +191,10 @@ func (s StackGo) SocketNetip(ctx context.Context, network string, family, sotype
 					if err = ctx.Err(); err != nil {
 						conn.Abort()
 						return nil, err
+					}
+					if conn.IsAwaitingControl() && time.Since(controlRetryAt) >= 0 {
+						conn.RequeueControl()
+						controlRetryAt = time.Now().Add(controlRetryInterval)
 					}
 				} else {
 					// Unexpected state, abort and terminate connection.

--- a/x/xnet/stack-retrying.go
+++ b/x/xnet/stack-retrying.go
@@ -93,12 +93,27 @@ func (s StackRetrying) DoResolveHardwareAddress6(addr netip.Addr, timeout time.D
 func (s StackRetrying) DoDialTCP(conn *tcp.Conn, localPort uint16, addrp netip.AddrPort, timeout time.Duration, retries int) (err error) {
 	expectEnd := time.Now().Add(timeout * time.Duration(retries))
 	var firstErr error
-	for range retries {
-		err = s.block.DoDialTCP(conn, localPort, addrp, timeout)
+	for i := range retries {
+		if i == 0 || conn.State().IsClosed() {
+			err = s.block.async.DialTCP(conn, localPort, addrp)
+			if err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+		} else if conn.IsAwaitingControl() {
+			conn.RequeueControl()
+		}
+
+		err = s.block.waitDialTCP(conn, timeout)
 		if err == nil {
 			return nil
 		} else if firstErr == nil {
 			firstErr = err
+		}
+		if !conn.IsAwaitingControl() {
+			conn.Abort()
 		}
 	}
 	if time.Now().Before(expectEnd) {

--- a/x/xnet/stack-retrying.go
+++ b/x/xnet/stack-retrying.go
@@ -13,9 +13,11 @@ func (s *StackAsync) StackRetrying(stackProtoBackoff lneto.BackoffStrategy) Stac
 	if stackProtoBackoff == nil {
 		panic("nil backoff to StackRetrying")
 	}
-	return StackRetrying{
-		block: s.StackBlocking(stackProtoBackoff),
-	}
+	return s.StackBlocking(stackProtoBackoff).StackRetrying()
+}
+
+func (s StackBlocking) StackRetrying() StackRetrying {
+	return StackRetrying{block: s}
 }
 
 var (

--- a/x/xnet/tcppool.go
+++ b/x/xnet/tcppool.go
@@ -42,7 +42,8 @@ type TCPPoolConfig struct {
 	ConnLogger *slog.Logger
 
 	// NanoTime returns the current monotonic time in nanoseconds.
-	// Used for pool timeout tracking. If nil, defaults to time.Now().UnixNano().
+	// Used for pool timeout tracking and passed to each [tcp.Conn] for
+	// retransmission timing (RFC 6298). If nil, defaults to time.Now().UnixNano().
 	NanoTime func() int64
 	// EstablishedTimeout sets the timeout for a TCP connection since it is acquired until it is established.
 	// If the connection does not establish in this time it will be closed by the pool.

--- a/x/xnet/tcppool.go
+++ b/x/xnet/tcppool.go
@@ -42,8 +42,7 @@ type TCPPoolConfig struct {
 	ConnLogger *slog.Logger
 
 	// NanoTime returns the current monotonic time in nanoseconds.
-	// Used for pool timeout tracking and passed to each [tcp.Conn] for
-	// retransmission timing (RFC 6298). If nil, defaults to time.Now().UnixNano().
+	// Used for pool timeout tracking. If nil, defaults to time.Now().UnixNano().
 	NanoTime func() int64
 	// EstablishedTimeout sets the timeout for a TCP connection since it is acquired until it is established.
 	// If the connection does not establish in this time it will be closed by the pool.

--- a/x/xnet/xnet_test.go
+++ b/x/xnet/xnet_test.go
@@ -2,10 +2,12 @@ package xnet
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"math/rand"
 	"net/netip"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -102,6 +104,57 @@ func TestTCPConn_ReadBlocksUntilDataAvailable(t *testing.T) {
 	}
 	if !bytes.Equal(readBuf[:readN], sendData) {
 		t.Fatalf("read data mismatch: got %q, want %q", readBuf[:readN], sendData)
+	}
+}
+
+func TestStackGoTCPDialRetriesPendingControl(t *testing.T) {
+	const seed = 5678
+	const MTU = ethernet.MaxMTU
+
+	client, sv, _, _ := newTCPStacks(t, seed, MTU)
+	sg := client.StackBlocking(backoffYield).StackGo(StackGoConfig{
+		ListenerPoolConfig: TCPPoolConfig{
+			QueueSize: 4,
+			TxBufSize: MTU,
+			RxBufSize: MTU,
+			NewBackoff: func() lneto.BackoffStrategy {
+				return backoffYield
+			},
+		},
+		TCPDialTimeout: 10 * time.Millisecond,
+		TCPDialRetries: 2,
+	})
+
+	laddr := netip.AddrPortFrom(netip.AddrFrom4(client.Addr4()), 1234)
+	raddr := netip.AddrPortFrom(netip.AddrFrom4(sv.Addr4()), 22)
+	done := make(chan error, 1)
+	go func() {
+		_, err := sg.SocketNetip(context.Background(), "tcp", syscall.AF_INET, sockSTREAM, laddr, raddr)
+		done <- err
+	}()
+
+	var buf [ethernet.MaxMTU + ethernet.MaxOverheadSize]byte
+	waitForEgress := func() {
+		t.Helper()
+		deadline := time.Now().Add(100 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			n, err := client.EgressEthernet(buf[:])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n > 0 {
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+		t.Fatal("timed out waiting for TCP dial egress packet")
+	}
+	waitForEgress()
+	waitForEgress()
+
+	err := <-done
+	if err == nil {
+		t.Fatal("expected TCP dial to fail after retries without peer response")
 	}
 }
 


### PR DESCRIPTION
  ## Summary

  Add SYN retransmission while a TCP connection is in `SYN-SENT`.

  Previously, lneto emitted the initial active-open SYN once and then waited for a SYN-ACK until the caller timeout expired. If that first SYN was dropped, the
  connection remained stuck in `SYN-SENT`.

  ## Change

  - Track the last SYN transmission time and SYN RTO in `tcp.Handler`.
  - Retransmit the same SYN with the same initial sequence number after the RTO expires.
  - Use exponential backoff from `1s` up to `4s`.
  - Add a regression test for SYN retransmission behavior.

  ## Validation

  ```sh
  go test ./tcp
  go test ./x/xnet