### PR TITLE
Add atomic id guard to prevent TOCTOU

### DIFF
--- a/internet/conn_closerace_test.go
+++ b/internet/conn_closerace_test.go
@@ -1,0 +1,214 @@
+package internet
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math/rand"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/soypat/lneto/tcp"
+)
+
+// TestConn_ConcurrentCloseDoesNotDropWrite is a regression test for issue #82:
+// when one goroutine has a Write in progress (blocked because the TX buffer is
+// full) and another goroutine calls Close, the in-flight write data must not be
+// silently dropped. With the atomic write-lock, Close waits for the in-progress
+// write to finish queueing all of its data before tearing the connection down.
+//
+// The scenario is made deterministic by filling the TX buffer before any packets
+// are exchanged: the writer blocks holding the write lock, Close is then issued
+// (and must wait), and only afterwards is the packet pump started so the buffer
+// can drain and the writer can run to completion.
+func TestConn_ConcurrentCloseDoesNotDropWrite(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	var sbCl, sbSv StackIPv4
+	var connCl, connSv tcp.Conn
+	setupClientServerEstablished(t, rng, &sbCl, &sbSv, &connCl, &connSv)
+
+	// Payload several times larger than the 2048-byte TX buffer so the writer
+	// must block waiting for the buffer to drain across many segments.
+	payload := make([]byte, 4*2048)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	// Watchdog: break any deadlock so a regression fails fast instead of hanging.
+	watchdog := time.AfterFunc(10*time.Second, func() {
+		t.Error("test timed out: Close likely blocked waiting on a stuck write")
+		connCl.Abort()
+		connSv.Abort()
+	})
+	defer watchdog.Stop()
+
+	// Writer (G1): writes the whole payload. Blocks once the TX buffer fills.
+	type writeResult struct {
+		n   int
+		err error
+	}
+	writeDone := make(chan writeResult, 1)
+	go func() {
+		n, err := connCl.Write(payload)
+		writeDone <- writeResult{n, err}
+	}()
+
+	// Wait until the writer has filled the TX buffer and is blocked. At this
+	// point it owns the write lock, reproducing "Write in progress".
+	for connCl.FreeOutput() != 0 {
+		runtime.Gosched()
+	}
+
+	// Close (G2): issued while the write is in progress. Must wait for the
+	// writer to drain instead of dropping its data.
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- connCl.Close()
+	}()
+
+	// Reader: drains the server side until EOF, accumulating everything received.
+	readDone := make(chan []byte, 1)
+	go func() {
+		got := make([]byte, 0, len(payload))
+		rbuf := make([]byte, 1024)
+		for {
+			n, err := connSv.Read(rbuf)
+			got = append(got, rbuf[:n]...)
+			if err != nil {
+				break
+			}
+		}
+		readDone <- got
+	}()
+
+	// Packet pump: only now do we move packets between the two stacks, letting
+	// the buffer drain so the blocked writer can finish.
+	var stop atomic.Bool
+	pumpStopped := make(chan struct{})
+	go func() {
+		defer close(pumpStopped)
+		var buf [2048]byte
+		for !stop.Load() {
+			progressed := false
+			if n, err := sbCl.Encapsulate(buf[:], 0, 0); err == nil && n > 0 {
+				_ = sbSv.Demux(buf[:n], 0)
+				progressed = true
+			}
+			if n, err := sbSv.Encapsulate(buf[:], 0, 0); err == nil && n > 0 {
+				_ = sbCl.Demux(buf[:n], 0)
+				progressed = true
+			}
+			if !progressed {
+				runtime.Gosched()
+			}
+		}
+	}()
+
+	wr := <-writeDone
+	if wr.err != nil {
+		t.Errorf("issue #82: Write returned error %v; concurrent Close dropped in-flight data", wr.err)
+	}
+	if wr.n != len(payload) {
+		t.Errorf("issue #82: Write wrote %d of %d bytes; concurrent Close truncated the write", wr.n, len(payload))
+	}
+	if err := <-closeDone; err != nil {
+		t.Errorf("Close returned error: %v", err)
+	}
+	got := <-readDone
+	stop.Store(true)
+	<-pumpStopped
+
+	if len(got) != len(payload) {
+		t.Fatalf("server received %d of %d bytes; data was dropped by concurrent Close", len(got), len(payload))
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("server received corrupted data")
+	}
+}
+
+// TestConn_ConcurrentWritesSerialize verifies that the atomic write-lock
+// serializes concurrent Write calls on the same connection so their payloads are
+// not interleaved on the wire, and that all bytes from both writers are delivered.
+func TestConn_ConcurrentWritesSerialize(t *testing.T) {
+	rng := rand.New(rand.NewSource(2))
+	var sbCl, sbSv StackIPv4
+	var connCl, connSv tcp.Conn
+	setupClientServerEstablished(t, rng, &sbCl, &sbSv, &connCl, &connSv)
+
+	const chunk = 1500
+	a := bytes.Repeat([]byte{0xAA}, chunk)
+	b := bytes.Repeat([]byte{0xBB}, chunk)
+
+	watchdog := time.AfterFunc(10*time.Second, func() {
+		t.Error("test timed out")
+		connCl.Abort()
+		connSv.Abort()
+	})
+	defer watchdog.Stop()
+
+	var stop atomic.Bool
+	pumpStopped := make(chan struct{})
+	go func() {
+		defer close(pumpStopped)
+		var buf [2048]byte
+		for !stop.Load() {
+			progressed := false
+			if n, err := sbCl.Encapsulate(buf[:], 0, 0); err == nil && n > 0 {
+				_ = sbSv.Demux(buf[:n], 0)
+				progressed = true
+			}
+			if n, err := sbSv.Encapsulate(buf[:], 0, 0); err == nil && n > 0 {
+				_ = sbCl.Demux(buf[:n], 0)
+				progressed = true
+			}
+			if !progressed {
+				runtime.Gosched()
+			}
+		}
+	}()
+
+	writeErr := make(chan error, 2)
+	writer := func(b []byte) {
+		n, err := connCl.Write(b)
+		if err == nil && n != len(b) {
+			err = io.ErrShortWrite
+		}
+		writeErr <- err
+	}
+	go writer(a)
+	go writer(b)
+
+	got := make([]byte, 0, 2*chunk)
+	rbuf := make([]byte, 1024)
+	for len(got) < 2*chunk {
+		n, err := connSv.Read(rbuf)
+		got = append(got, rbuf[:n]...)
+		if err != nil && !errors.Is(err, io.EOF) {
+			break
+		}
+	}
+	for range 2 {
+		if err := <-writeErr; err != nil {
+			t.Errorf("concurrent write failed: %v", err)
+		}
+	}
+	stop.Store(true)
+	<-pumpStopped
+
+	if len(got) != 2*chunk {
+		t.Fatalf("received %d bytes, want %d", len(got), 2*chunk)
+	}
+	// Serialized writes mean one chunk's bytes appear fully before the other's;
+	// the boundary is a single transition, never interleaved.
+	transitions := 0
+	for i := 1; i < len(got); i++ {
+		if got[i] != got[i-1] {
+			transitions++
+		}
+	}
+	if transitions != 1 {
+		t.Fatalf("expected exactly one A/B boundary (serialized writes), got %d transitions", transitions)
+	}
+}

--- a/tcp/conn.go
+++ b/tcp/conn.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/soypat/lneto"
@@ -29,6 +30,14 @@ type Conn struct {
 	h          Handler
 	remoteAddr []byte
 
+	// writeLock holds the connection ID ([Handler.connid]) of the goroutine
+	// that currently owns the write side via [Conn.Write] or [Conn.Flush].
+	// A zero value means no write is in progress. It serializes concurrent
+	// writers and lets [Conn.Close] wait for an in-flight write to finish
+	// queueing its data instead of dropping it (see issue #82). It is an atomic
+	// so Close can poll it without contending on mu while a writer drains.
+	writeLock atomic.Uint64
+
 	_backoff lneto.BackoffStrategy
 	rdead    time.Time
 	wdead    time.Time
@@ -37,6 +46,12 @@ type Conn struct {
 
 	ipID uint16
 }
+
+// maxCloseDrainBackoffs bounds how many backoff iterations [Conn.Close] waits
+// for an in-progress write to drain before closing regardless. It is a safety
+// net against a writer that can never make progress (e.g. a dead peer with no
+// write deadline); a writer with a deadline releases the lock far sooner.
+const maxCloseDrainBackoffs = 1 << 16
 
 // reset must be called while holding [Conn.mu].
 func (conn *Conn) reset(h Handler) {
@@ -49,6 +64,7 @@ func (conn *Conn) reset(h Handler) {
 	conn.wdead = time.Time{}
 	conn.abortErr = nil
 	conn.ipID = 0
+	conn.writeLock.Store(0)
 }
 
 type ConnConfig struct {
@@ -202,6 +218,18 @@ func (conn *Conn) CloseRead() error {
 
 func (conn *Conn) Close() error {
 	conn.mu.Lock()
+	connid := conn.h.connid
+	conn.mu.Unlock()
+	// Wait for an in-progress Write/Flush on this connection to finish queueing
+	// its data so that closing does not silently drop it (issue #82). The wait is
+	// bounded so a writer that can never make progress does not block Close forever.
+	for backoffs := uint(0); connid != 0 && backoffs < maxCloseDrainBackoffs; backoffs++ {
+		if conn.writeLock.Load() != connid {
+			break // No writer owns this connection's write side.
+		}
+		conn.backoff(backoffs)
+	}
+	conn.mu.Lock()
 	defer conn.mu.Unlock()
 	conn.trace("TCPConn.Close", slog.Uint64("lport", uint64(conn.h.localPort)), slog.Uint64("rport", uint64(conn.h.remotePort)))
 	return conn.h.Close()
@@ -225,10 +253,11 @@ func (conn *Conn) InternalHandler() *Handler {
 
 // Write writes argument data to the TCPConns's output buffer which is queued to be sent.
 func (conn *Conn) Write(b []byte) (int, error) {
-	connid, err := conn.lockPipeConnID()
+	connid, err := conn.beginWrite()
 	if err != nil {
 		return 0, err
 	}
+	defer conn.endWrite(connid)
 	rport := conn.RemotePort()
 	plen := len(b)
 	lport := conn.LocalPort()
@@ -273,10 +302,11 @@ func (conn *Conn) Write(b []byte) (int, error) {
 }
 
 func (conn *Conn) Flush() error {
-	connid, err := conn.lockPipeConnID()
+	connid, err := conn.beginWrite()
 	if err != nil {
 		return err
 	}
+	defer conn.endWrite(connid)
 	var backoffs uint
 	for conn.BufferedUnsent() != 0 {
 		if err := conn.checkPipe(connid, &conn.wdead); err != nil {
@@ -337,14 +367,42 @@ func (conn *Conn) Read(b []byte) (int, error) {
 	return n, nil
 }
 
-func (conn *Conn) lockPipeConnID() (uint64, error) {
-	conn.mu.Lock()
-	defer conn.mu.Unlock()
-	err := conn.checkPipeOpen()
-	if err != nil {
-		return 0, err
+// beginWrite validates the connection is open and acquires the write lock for
+// the current connection, returning its connection ID. It serializes concurrent
+// writers: while another goroutine owns the write side it blocks with backoff
+// until that writer releases or the connection closes or the write deadline
+// elapses. The returned connID must be released with [Conn.endWrite].
+//
+// The lock is acquired while holding mu so that a concurrent [Conn.Close]
+// observing writeLock cannot race past an in-progress write.
+func (conn *Conn) beginWrite() (connID uint64, err error) {
+	var backoffs uint
+	for {
+		conn.mu.Lock()
+		err = conn.checkPipeOpen()
+		if err != nil {
+			conn.mu.Unlock()
+			return 0, err
+		}
+		connID = conn.h.connid
+		if conn.writeLock.CompareAndSwap(0, connID) {
+			conn.mu.Unlock()
+			return connID, nil
+		}
+		// Another writer owns the write side. Honor the write deadline while waiting.
+		exceeded := !conn.wdead.IsZero() && time.Since(conn.wdead) > 0
+		conn.mu.Unlock()
+		if exceeded {
+			return 0, errDeadlineExceeded
+		}
+		conn.backoff(backoffs)
+		backoffs++
 	}
-	return conn.h.connid, nil
+}
+
+// endWrite releases a write lock previously acquired by [Conn.beginWrite].
+func (conn *Conn) endWrite(connID uint64) {
+	conn.writeLock.CompareAndSwap(connID, 0)
 }
 
 func (conn *Conn) checkPipe(connID uint64, deadline *time.Time) (err error) {

--- a/tcp/conn.go
+++ b/tcp/conn.go
@@ -33,9 +33,8 @@ type Conn struct {
 	// writeLock holds the connection ID ([Handler.connid]) of the goroutine
 	// that currently owns the write side via [Conn.Write] or [Conn.Flush].
 	// A zero value means no write is in progress. It serializes concurrent
-	// writers and lets [Conn.Close] wait for an in-flight write to finish
-	// queueing its data instead of dropping it (see issue #82). It is an atomic
-	// so Close can poll it without contending on mu while a writer drains.
+	// writers and lets [Conn.Close] acquire the write side before closing so it
+	// does not drop in-flight data (see issue #82).
 	writeLock atomic.Uint64
 
 	_backoff lneto.BackoffStrategy
@@ -46,12 +45,6 @@ type Conn struct {
 
 	ipID uint16
 }
-
-// maxCloseDrainBackoffs bounds how many backoff iterations [Conn.Close] waits
-// for an in-progress write to drain before closing regardless. It is a safety
-// net against a writer that can never make progress (e.g. a dead peer with no
-// write deadline); a writer with a deadline releases the lock far sooner.
-const maxCloseDrainBackoffs = 1 << 16
 
 // reset must be called while holding [Conn.mu].
 func (conn *Conn) reset(h Handler) {
@@ -217,18 +210,11 @@ func (conn *Conn) CloseRead() error {
 }
 
 func (conn *Conn) Close() error {
-	conn.mu.Lock()
-	connid := conn.h.connid
-	conn.mu.Unlock()
-	// Wait for an in-progress Write/Flush on this connection to finish queueing
-	// its data so that closing does not silently drop it (issue #82). The wait is
-	// bounded so a writer that can never make progress does not block Close forever.
-	for backoffs := uint(0); connid != 0 && backoffs < maxCloseDrainBackoffs; backoffs++ {
-		if conn.writeLock.Load() != connid {
-			break // No writer owns this connection's write side.
-		}
-		conn.backoff(backoffs)
+	connid, err := conn.acquireWriteLock(nil)
+	if err != nil {
+		return err
 	}
+	defer conn.releaseWriteLock(connid)
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 	conn.trace("TCPConn.Close", slog.Uint64("lport", uint64(conn.h.localPort)), slog.Uint64("rport", uint64(conn.h.remotePort)))
@@ -253,11 +239,11 @@ func (conn *Conn) InternalHandler() *Handler {
 
 // Write writes argument data to the TCPConns's output buffer which is queued to be sent.
 func (conn *Conn) Write(b []byte) (int, error) {
-	connid, err := conn.beginWrite()
+	connid, err := conn.acquireWriteLock(&conn.wdead)
 	if err != nil {
 		return 0, err
 	}
-	defer conn.endWrite(connid)
+	defer conn.releaseWriteLock(connid)
 	rport := conn.RemotePort()
 	plen := len(b)
 	lport := conn.LocalPort()
@@ -302,11 +288,11 @@ func (conn *Conn) Write(b []byte) (int, error) {
 }
 
 func (conn *Conn) Flush() error {
-	connid, err := conn.beginWrite()
+	connid, err := conn.acquireWriteLock(&conn.wdead)
 	if err != nil {
 		return err
 	}
-	defer conn.endWrite(connid)
+	defer conn.releaseWriteLock(connid)
 	var backoffs uint
 	for conn.BufferedUnsent() != 0 {
 		if err := conn.checkPipe(connid, &conn.wdead); err != nil {
@@ -367,41 +353,30 @@ func (conn *Conn) Read(b []byte) (int, error) {
 	return n, nil
 }
 
-// beginWrite validates the connection is open and acquires the write lock for
-// the current connection, returning its connection ID. It serializes concurrent
-// writers: while another goroutine owns the write side it blocks with backoff
-// until that writer releases or the connection closes or the write deadline
-// elapses. The returned connID must be released with [Conn.endWrite].
-//
-// The lock is acquired while holding mu so that a concurrent [Conn.Close]
-// observing writeLock cannot race past an in-progress write.
-func (conn *Conn) beginWrite() (connID uint64, err error) {
+// acquireWriteLock validates the connection is open and acquires the write lock
+// for the current connection, returning its connection ID. It serializes
+// concurrent writers: while another goroutine owns the write side it blocks with
+// backoff until that writer releases, the connection closes, or deadline elapses.
+// The returned connID must be released with [Conn.releaseWriteLock].
+func (conn *Conn) acquireWriteLock(deadline *time.Time) (connID uint64, err error) {
+	conn.mu.Lock()
+	connID = conn.h.connid
+	conn.mu.Unlock()
 	var backoffs uint
 	for {
-		conn.mu.Lock()
-		err = conn.checkPipeOpen()
-		if err != nil {
-			conn.mu.Unlock()
+		if err := conn.checkPipe(connID, deadline); err != nil {
 			return 0, err
 		}
-		connID = conn.h.connid
 		if conn.writeLock.CompareAndSwap(0, connID) {
-			conn.mu.Unlock()
 			return connID, nil
-		}
-		// Another writer owns the write side. Honor the write deadline while waiting.
-		exceeded := !conn.wdead.IsZero() && time.Since(conn.wdead) > 0
-		conn.mu.Unlock()
-		if exceeded {
-			return 0, errDeadlineExceeded
 		}
 		conn.backoff(backoffs)
 		backoffs++
 	}
 }
 
-// endWrite releases a write lock previously acquired by [Conn.beginWrite].
-func (conn *Conn) endWrite(connID uint64) {
+// releaseWriteLock releases a write lock previously acquired by [Conn.acquireWriteLock].
+func (conn *Conn) releaseWriteLock(connID uint64) {
 	conn.writeLock.CompareAndSwap(connID, 0)
 }
 
@@ -410,9 +385,9 @@ func (conn *Conn) checkPipe(connID uint64, deadline *time.Time) (err error) {
 	defer conn.mu.Unlock()
 	if conn.abortErr != nil {
 		err = conn.abortErr
-	} else if connID != conn.h.connid {
+	} else if connID != conn.h.connid || conn.h.State().IsClosed() {
 		err = net.ErrClosed
-	} else if !deadline.IsZero() && time.Since(*deadline) > 0 {
+	} else if deadline != nil && !deadline.IsZero() && time.Since(*deadline) > 0 {
 		err = errDeadlineExceeded
 	}
 	return err


### PR DESCRIPTION
This resolves #82 as suggested by @soypat to use a write lock via a atomic uint64.