### PR TITLE
fix(xnet): remove maxIter cap from waitDialTCP

### DIFF
--- a/x/xnet/stack-blocking.go
+++ b/x/xnet/stack-blocking.go
@@ -191,7 +191,7 @@ func (s StackBlocking) DoDialTCP(conn *tcp.Conn, localPort uint16, addrp netip.A
 func (s StackBlocking) waitDialTCP(conn *tcp.Conn, timeout time.Duration) (err error) {
 	deadline := time.Now().Add(timeout)
 	var backoffs uint
-	for range maxIter {
+	for {
 		state := conn.State()
 		if state == tcp.StateEstablished {
 			return nil
@@ -206,7 +206,6 @@ func (s StackBlocking) waitDialTCP(conn *tcp.Conn, timeout time.Duration) (err e
 		s.backoff(backoffs)
 		backoffs++
 	}
-	return errDeadlineExceed
 }
 
 func (s StackBlocking) checkDeadline(deadline time.Time) error {


### PR DESCRIPTION
The function used `for range maxIter` (1000 iterations) as an exit guard. With a Gosched backoff, 1000 iterations complete in ~1ms, well before the configured dial timeout. When the loop exhausted, the connection was in AwaitingSynSend (SYN not yet emitted) so IsAwaitingControl() returned false causing the conn to be aborted instead of requeued. This causes the retry to start fresh and the test's EgressEthernet driver to never observe a SYN.

Replace the bounded loop with an infinite loop whose only exit paths are the deadline check, StateEstablished, or an unexpected state. The timeout is now the sole time limit, matching caller intent.

Fixes TestStackGoTCPDialRetriesPendingControl which failed deterministically without the race detector.