### PR TITLE
EXPERIMENT: bump go to 1.25 and use synctest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/soypat/lneto
 
-go 1.24
+go 1.25

--- a/x/xnet/stack-blocking.go
+++ b/x/xnet/stack-blocking.go
@@ -31,15 +31,11 @@ func (s *StackAsync) StackBlocking(stackProtoBackoff lneto.BackoffStrategy) Stac
 }
 
 type StackBlocking struct {
-	async     *StackAsync
-	_backoff  lneto.BackoffStrategy
-	_nanotime func() int64
+	async    *StackAsync
+	_backoff lneto.BackoffStrategy
 }
 
 func (s StackBlocking) nanotime() int64 {
-	if s._nanotime != nil {
-		return s._nanotime()
-	}
 	return time.Now().UnixNano()
 }
 

--- a/x/xnet/xnet_dialretry_synctest_test.go
+++ b/x/xnet/xnet_dialretry_synctest_test.go
@@ -1,0 +1,101 @@
+//go:build !tinygo
+
+// synctest is unavailable under TinyGo, so this deterministic dial-retry test is
+// excluded from TinyGo builds. The retry/timeout logic it exercises is platform
+// independent and fully covered when run with the standard Go toolchain.
+package xnet
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"syscall"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/soypat/lneto"
+	"github.com/soypat/lneto/ethernet"
+	"github.com/soypat/lneto/tcp"
+)
+
+// TestStackGoTCPDialRetriesPendingControl verifies that an active TCP dial fails
+// after exhausting its retries when the peer never responds to the SYN.
+//
+// It runs inside a synctest bubble so the time package uses a fake clock: backoff
+// sleeps advance logical time deterministically and the dial deadline/retries are
+// reached without any real waiting or wall-clock flakiness.
+//
+// The test goroutine first uses synctest.Wait to let the dialing goroutine emit and
+// durably block after its first SYN, drains and asserts that SYN, then blocks on the
+// result channel. Blocking on the channel is what lets synctest advance the fake
+// clock: only when every goroutine is durably blocked does time move forward, waking
+// the dialing goroutine from backoff until the deadline and retries are exhausted.
+func TestStackGoTCPDialRetriesPendingControl(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const seed = 5678
+		const MTU = ethernet.MaxMTU
+		const tcptimeout = time.Second
+		client, sv, _, _ := newTCPStacks(t, seed, MTU)
+
+		// Backoff sleeps a real (fake-clocked) duration so the dial deadline and
+		// retry counter advance deterministically under synctest.
+		dialBackoff := func(consecutiveBackoffs uint) time.Duration { return tcptimeout / 10 }
+		sg := client.StackBlocking(dialBackoff).StackGo(StackGoConfig{
+			ListenerPoolConfig: TCPPoolConfig{
+				QueueSize:  4,
+				TxBufSize:  MTU,
+				RxBufSize:  MTU,
+				NewBackoff: func() lneto.BackoffStrategy { return dialBackoff },
+			},
+			TCPDialTimeout: tcptimeout,
+			TCPDialRetries: 2,
+		})
+
+		laddr := netip.AddrPortFrom(netip.AddrFrom4(client.Addr4()), 1234)
+		raddr := netip.AddrPortFrom(netip.AddrFrom4(sv.Addr4()), 22)
+		done := make(chan error, 1)
+		go func() {
+			_, err := sg.SocketNetip(context.Background(), "tcp", syscall.AF_INET, sockSTREAM, laddr, raddr)
+			done <- err
+		}()
+
+		// Let the dialing goroutine run until it durably blocks in backoff, by which
+		// point it has queued its first SYN. Drain and assert it without responding,
+		// so the dial is forced to time out and retry.
+		synctest.Wait()
+		assertOutboundSYN(t, client, 1)
+
+		// With no peer response the dial must exhaust its deadline and retries and
+		// fail. Blocking here lets the fake clock advance until that happens.
+		err := <-done
+
+		// The original scheduler-based test verified the retry by checking the
+		// second SYN packet too. Keep that coverage before accepting the final error.
+		assertOutboundSYN(t, client, 2)
+
+		if err == nil {
+			t.Fatal("expected TCP dial to fail after retries without peer response")
+		}
+		if !errors.Is(err, errDeadlineExceed) && !errors.Is(err, errRetriesExceeded) {
+			t.Fatalf("expected deadline/retries error, got %v", err)
+		}
+	})
+}
+
+func assertOutboundSYN(t testing.TB, client *StackAsync, wantPacket int) {
+	t.Helper()
+	var buf [ethernet.MaxMTU + ethernet.MaxOverheadSize]byte
+	n, err := client.EgressEthernet(buf[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	frm, ok := getTCPFrame(buf[:n])
+	if !ok {
+		t.Fatalf("expected outbound TCP SYN packet %d from dial", wantPacket)
+	}
+	_, flags := frm.OffsetAndFlags()
+	if flags != tcp.FlagSYN {
+		t.Fatalf("expected SYN packet %d, got %s", wantPacket, flags.String())
+	}
+}

--- a/x/xnet/xnet_test.go
+++ b/x/xnet/xnet_test.go
@@ -2,12 +2,10 @@ package xnet
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"math/rand"
 	"net/netip"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 
@@ -29,57 +27,6 @@ const (
 	pshack = tcp.FlagPSH | tcp.FlagACK
 	finack = tcp.FlagFIN | tcp.FlagACK
 )
-
-func newstackTestScheduler(t testing.TB) stackTestScheduler {
-	return stackTestScheduler{
-		t:                   t,
-		stackBackoffSignal:  make(chan struct{}),
-		stackContinueSignal: make(chan struct{}),
-		timeout:             time.Second,
-	}
-}
-
-type stackTestScheduler struct {
-	t testing.TB
-	// when stack backs off it signals here and waits until channel read or timeout.
-	stackBackoffSignal chan struct{}
-	// when main goroutine is ready for more information this channel is written to to signal waiting on stack activity.
-	stackContinueSignal chan struct{}
-	timeout             time.Duration
-}
-
-func (ss *stackTestScheduler) backoffStack(consecutiveBackoffs uint) time.Duration {
-	timeout := time.After(ss.timeout)
-	select {
-	case ss.stackBackoffSignal <- struct{}{}:
-	case <-timeout:
-		ss.t.Fatal("timeout backing off, possible race condition? Multiple stacks using same backoff is unexpected pattern")
-	}
-	select {
-	case <-ss.stackContinueSignal:
-	case <-timeout:
-		ss.t.Fatal("timeout waiting for continue")
-	}
-	return lneto.BackoffFlagNop // backoff yield implemented on our side.
-}
-
-func (ss *stackTestScheduler) mainGoroutineWaitForStackYield() {
-	timeout := time.After(ss.timeout)
-	select {
-	case <-ss.stackBackoffSignal:
-	case <-timeout:
-		ss.t.Fatal("timeout waiting for stack to backoff")
-	}
-}
-
-func (ss *stackTestScheduler) mainGoroutineYieldToStack() {
-	timeout := time.After(ss.timeout)
-	select {
-	case ss.stackContinueSignal <- struct{}{}:
-	case <-timeout:
-		ss.t.Fatal("timeout while trying to yield to stack")
-	}
-}
 
 func TestTCPConn_ReadBlocksUntilDataAvailable(t *testing.T) {
 	const seed = 5678
@@ -155,78 +102,6 @@ func TestTCPConn_ReadBlocksUntilDataAvailable(t *testing.T) {
 	}
 	if !bytes.Equal(readBuf[:readN], sendData) {
 		t.Fatalf("read data mismatch: got %q, want %q", readBuf[:readN], sendData)
-	}
-}
-
-func TestStackGoTCPDialRetriesPendingControl(t *testing.T) {
-	const seed = 5678
-	const MTU = ethernet.MaxMTU
-	const tcptimeout = time.Second
-	const yield = 1 * time.Millisecond
-	client, sv, _, _ := newTCPStacks(t, seed, MTU)
-	tbackoffer := newstackTestScheduler(t)
-
-	sg := client.StackBlocking(tbackoffer.backoffStack).StackGo(StackGoConfig{
-		ListenerPoolConfig: TCPPoolConfig{
-			QueueSize: 4,
-			TxBufSize: MTU,
-			RxBufSize: MTU,
-			NewBackoff: func() lneto.BackoffStrategy {
-				return backoffYield
-			},
-		},
-		TCPDialTimeout: tcptimeout,
-		TCPDialRetries: 2,
-	})
-	t.Log("start")
-	// closure to simulate time.
-	var now time.Duration
-	sg.blk._nanotime = func() int64 { return int64(now) }
-
-	laddr := netip.AddrPortFrom(netip.AddrFrom4(client.Addr4()), 1234)
-	raddr := netip.AddrPortFrom(netip.AddrFrom4(sv.Addr4()), 22)
-	done := make(chan error, 1)
-	go func() {
-		_, err := sg.SocketNetip(context.Background(), "tcp", syscall.AF_INET, sockSTREAM, laddr, raddr)
-		done <- err
-	}()
-	npacket := 0
-	ntcppacket := 0
-	var buf [ethernet.MaxMTU + ethernet.MaxOverheadSize]byte
-	for !t.Failed() { // Tinygo does not implement failnow.
-		tbackoffer.mainGoroutineWaitForStackYield()
-		n, err := client.EgressEthernet(buf[:])
-		now += tcptimeout / 100
-		if err != nil {
-			t.Fatal(err)
-		} else if n == 0 {
-			t.Fatal("expected packet from socketnetip", npacket, ntcppacket)
-		}
-		npacket++
-		frm, ok := getTCPFrame(buf[:])
-		if !ok {
-			tbackoffer.mainGoroutineYieldToStack()
-			continue
-		}
-		ntcppacket++
-		_, flags := frm.OffsetAndFlags()
-		if flags != tcp.FlagSYN {
-			t.Fatal("expected SYN packet")
-		}
-		switch ntcppacket {
-		case 1:
-			now += 2 * tcptimeout
-			tbackoffer.mainGoroutineYieldToStack()
-		case 2:
-			now += 2 * tcptimeout
-			tbackoffer.mainGoroutineYieldToStack()
-			select {
-			case <-time.After(time.Second):
-				t.Fatal("SocketNetip hanging")
-			case <-done:
-				return // Test success.
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
In 1.24 synctest was added as an experiment and it got stabilized further in 1.25. This also migrates a test to it for initial evaluation.