### PR TITLE
Add RFC 7323 timestamp negotiation and RTT sampling

### DIFF
--- a/tcp/conn.go
+++ b/tcp/conn.go
@@ -82,10 +82,16 @@ type ConnConfig struct {
 	// recovery. See [LossRecovery].
 	LossRecovery LossRecovery
 	// Nanotime is the monotonic time source in nanoseconds (the func() int64
-	// convention used across lneto) that drives LossRecovery. It is required when
-	// LossRecovery is set and unused otherwise. The tcp package reads it only to
-	// stamp the loss-recovery hooks; it holds no clock itself.
+	// convention used across lneto). It is the connection's TCP clock: it drives
+	// LossRecovery and generates the RFC 7323 timestamp clock when
+	// EnableTimestamps is set. Required when either LossRecovery or
+	// EnableTimestamps is set, and unused otherwise. The tcp package reads it only
+	// to stamp segments; it holds no clock itself.
 	Nanotime func() int64
+	// EnableTimestamps opts into the RFC 7323 Timestamps option, negotiated on
+	// the handshake and used to measure the round-trip time. It requires Nanotime
+	// (else Configure returns an error). See [Handler.EnableTimestamps].
+	EnableTimestamps bool
 }
 
 // Configure should be called on any newly created connection before usage. See [ConnConfig].
@@ -93,8 +99,9 @@ func (conn *Conn) Configure(config ConnConfig) (err error) {
 	if config.RWBackoff == nil {
 		return lneto.ErrMissingHALConfig
 	}
-	if config.LossRecovery != nil && config.Nanotime == nil {
-		// The tcp package holds no clock: a loss-recovery algorithm cannot run without it.
+	if (config.LossRecovery != nil || config.EnableTimestamps) && config.Nanotime == nil {
+		// The tcp package holds no clock: neither loss recovery nor the RFC 7323
+		// timestamp clock can run without an injected time source.
 		return lneto.ErrInvalidConfig
 	}
 	conn.mu.Lock()
@@ -106,6 +113,9 @@ func (conn *Conn) Configure(config ConnConfig) (err error) {
 	conn._backoff = config.RWBackoff
 	conn.logger.log = config.Logger
 	conn.h.SetLossRecovery(config.LossRecovery, config.Nanotime)
+	if err = conn.h.EnableTimestamps(config.EnableTimestamps); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/tcp/conn_test.go
+++ b/tcp/conn_test.go
@@ -24,6 +24,36 @@ func newConfiguredConn(t *testing.T) *Conn {
 	return &conn
 }
 
+// TestConn_Configure_Timestamps verifies RFC 7323 timestamps can be enabled
+// through the public ConnConfig surface, and that doing so without a clock is
+// rejected rather than silently ignored.
+func TestConn_Configure_Timestamps(t *testing.T) {
+	var withClock Conn
+	err := withClock.Configure(ConnConfig{
+		RxBuf:             make([]byte, 512),
+		TxBuf:             make([]byte, 512),
+		TxPacketQueueSize: 4,
+		RWBackoff:         backoffYield,
+		EnableTimestamps:  true,
+		Nanotime:          func() int64 { return 1 },
+	})
+	if err != nil {
+		t.Fatal("configure with clock:", err)
+	}
+
+	var noClock Conn
+	err = noClock.Configure(ConnConfig{
+		RxBuf:             make([]byte, 512),
+		TxBuf:             make([]byte, 512),
+		TxPacketQueueSize: 4,
+		RWBackoff:         backoffYield,
+		EnableTimestamps:  true, // no Nanotime.
+	})
+	if err != lneto.ErrInvalidConfig {
+		t.Fatalf("configure timestamps without clock = %v, want ErrInvalidConfig", err)
+	}
+}
+
 func TestConn_SetDeadline_Closed(t *testing.T) {
 	conn := newConfiguredConn(t)
 	err := conn.SetDeadline(time.Now().Add(time.Second))

--- a/tcp/control.go
+++ b/tcp/control.go
@@ -79,10 +79,21 @@ type ControlBlock struct {
 	dupack uint8
 	// nRetransmit counts number of retransmits sent since last UNA update.
 	nRetransmit uint8
+
+	// tsEnabled reports whether the TCP Timestamps option (RFC 7323) was
+	// negotiated on both ends during the handshake.
+	tsEnabled bool
+	// tsRecent is the most recent timestamp received from the peer (TS.Recent,
+	// RFC 7323 §4.3), echoed back as TSecr so the peer can measure RTT.
+	tsRecent uint32
 }
 
 // State returns the current state of the TCP connection. See [State].
 func (tcb *ControlBlock) State() State { return tcb._state }
+
+// TimestampsEnabled reports whether the RFC 7323 Timestamps option was
+// negotiated for this connection.
+func (tcb *ControlBlock) TimestampsEnabled() bool { return tcb.tsEnabled }
 
 // RecvNext returns the next sequence number expected to be received from remote.
 // This implementation will reject segments that are not the next expected sequence.

--- a/tcp/control.go
+++ b/tcp/control.go
@@ -75,25 +75,23 @@ type ControlBlock struct {
 	// A negative value of challengeAcks means a challenge ack is pending being sent.
 	challengeAcks int8
 
+	// tsRecent is the most recent timestamp received from the peer (TS.Recent,
+	// RFC 7323 §4.3), echoed back as TSecr so the peer can measure RTT. Placed
+	// with the other multi-byte fields; the single-byte flags below are grouped
+	// together to avoid alignment padding.
+	tsRecent uint32
+
 	// dupack counts received ACK==snd.UNA && ACK<snd.NXT received. Does not count ack that set UNA.
 	dupack uint8
 	// nRetransmit counts number of retransmits sent since last UNA update.
 	nRetransmit uint8
-
 	// tsEnabled reports whether the TCP Timestamps option (RFC 7323) was
 	// negotiated on both ends during the handshake.
 	tsEnabled bool
-	// tsRecent is the most recent timestamp received from the peer (TS.Recent,
-	// RFC 7323 §4.3), echoed back as TSecr so the peer can measure RTT.
-	tsRecent uint32
 }
 
 // State returns the current state of the TCP connection. See [State].
 func (tcb *ControlBlock) State() State { return tcb._state }
-
-// TimestampsEnabled reports whether the RFC 7323 Timestamps option was
-// negotiated for this connection.
-func (tcb *ControlBlock) TimestampsEnabled() bool { return tcb.tsEnabled }
 
 // RecvNext returns the next sequence number expected to be received from remote.
 // This implementation will reject segments that are not the next expected sequence.

--- a/tcp/definitions.go
+++ b/tcp/definitions.go
@@ -52,10 +52,14 @@ type Segment struct {
 	Flags   Flags // TCP flags.
 
 	// TSEcr is the RFC 7323 Timestamps echo reply (TSecr) carried by an incoming
-	// segment when the option is negotiated: the peer's echo of a TSval we sent,
-	// used to measure the round-trip time. It is not part of the fixed header and
-	// is zero when timestamps are not in use. See [LossRecovery.PreRx].
+	// segment: the peer's echo of a TSval we sent, used to measure the round-trip
+	// time. It is not part of the fixed header. Zero is a valid echo value, so
+	// TSPresent (not TSEcr == 0) reports whether the option was actually present.
+	// See [LossRecovery.PreRx].
 	TSEcr uint32
+	// TSPresent reports whether the incoming segment carried the RFC 7323
+	// Timestamps option, so a valid zero TSEcr is not mistaken for "absent".
+	TSPresent bool
 }
 
 // LEN returns the length of the segment in octets including SYN and FIN flags.

--- a/tcp/definitions.go
+++ b/tcp/definitions.go
@@ -50,6 +50,12 @@ type Segment struct {
 	DATALEN Size  // The number of octets occupied by the data (payload) not counting SYN and FIN.
 	WND     Size  // segment window
 	Flags   Flags // TCP flags.
+
+	// TSEcr is the RFC 7323 Timestamps echo reply (TSecr) carried by an incoming
+	// segment when the option is negotiated: the peer's echo of a TSval we sent,
+	// used to measure the round-trip time. It is not part of the fixed header and
+	// is zero when timestamps are not in use. See [LossRecovery.PreRx].
+	TSEcr uint32
 }
 
 // LEN returns the length of the segment in octets including SYN and FIN flags.

--- a/tcp/frame.go
+++ b/tcp/frame.go
@@ -10,6 +10,10 @@ import (
 
 const (
 	sizeHeaderTCP = 20
+	// maxTCPOptionBytes is the largest TCP option area: the data-offset field
+	// counts 32-bit words, so the header spans at most 15*4 = 60 bytes, leaving
+	// 40 bytes for options after the 20-byte fixed header.
+	maxTCPOptionBytes = 40
 )
 
 // NewFrame returns a new [Frame] with data set to buf.

--- a/tcp/handler.go
+++ b/tcp/handler.go
@@ -250,6 +250,13 @@ func (h *Handler) Recv(incomingPacket []byte) error {
 	}
 	payload := tfrm.Payload()
 	segIncoming := tfrm.Segment(len(payload))
+	if h.scb.tsEnabled {
+		// Expose the echoed timestamp so loss recovery can measure RTT from it
+		// (RFC 7323 §4.2). Only meaningful once the option has been negotiated.
+		if _, tsecr, present := h.timestampFromOptions(tfrm.Options()); present {
+			segIncoming.TSEcr = tsecr
+		}
+	}
 	if h.scb.IncomingIsKeepalive(segIncoming) {
 		h.info("tcp.Handler:rx-keepalive", slog.Uint64("port", uint64(h.localPort)))
 		return nil

--- a/tcp/handler.go
+++ b/tcp/handler.go
@@ -84,10 +84,12 @@ func (h *Handler) SetBuffers(txbuf, rxbuf []byte, packets int) error {
 }
 
 // SetLossRecovery installs the packet-loss recovery algorithm and the monotonic
-// time source (nanoseconds, the func() int64 convention used across lneto) that
-// drives it. The tcp package keeps no clock of its own; nanotime is read only to
-// stamp the rx/tx hooks (see [LossRecovery]). Passing loss == nil disables loss
-// recovery. It should be set before the connection is opened.
+// time source (nanoseconds, the func() int64 convention used across lneto). The
+// tcp package keeps no clock of its own: nanotime is the connection's TCP clock,
+// read to stamp the loss-recovery rx/tx hooks (see [LossRecovery]) and, when
+// enabled, to generate the RFC 7323 timestamp clock (see
+// [Handler.EnableTimestamps]). Passing loss == nil disables loss recovery but
+// still installs the clock. It should be set before the connection is opened.
 func (h *Handler) SetLossRecovery(loss LossRecovery, nanotime func() int64) {
 	h.loss = loss
 	h.nanotime = nanotime
@@ -251,10 +253,18 @@ func (h *Handler) Recv(incomingPacket []byte) error {
 	payload := tfrm.Payload()
 	segIncoming := tfrm.Segment(len(payload))
 	if h.scb.tsEnabled {
-		// Expose the echoed timestamp so loss recovery can measure RTT from it
-		// (RFC 7323 §4.2). Only meaningful once the option has been negotiated.
-		if _, tsecr, present := h.timestampFromOptions(tfrm.Options()); present {
+		_, tsecr, present := h.timestampFromOptions(tfrm.Options())
+		if present {
+			// Expose the echoed timestamp so loss recovery can measure RTT from
+			// it (RFC 7323 §4.2). Only meaningful once negotiated.
 			segIncoming.TSEcr = tsecr
+			segIncoming.TSPresent = true
+		} else if !segIncoming.Flags.HasAny(FlagRST) {
+			// RFC 7323 §3.2: once the option is negotiated every non-RST segment
+			// must carry it. Silently drop one that omits it — accepting it could
+			// permit undetectable data corruption. PAWS itself is not implemented.
+			h.debug("tcp.Handler:rx-drop-missing-ts", slog.Uint64("port", uint64(h.localPort)))
+			return nil
 		}
 	}
 	if h.scb.IncomingIsKeepalive(segIncoming) {
@@ -463,8 +473,8 @@ func (h *Handler) timestampFromOptions(opts []byte) (tsval, tsecr uint32, presen
 
 // processTimestamps negotiates and applies the RFC 7323 Timestamps option for an
 // accepted incoming segment: it negotiates support on the SYN and refreshes the
-// echoed TS.Recent value for in-order segments (§4.3) so the peer can measure
-// RTT from the echo.
+// echoed TS.Recent value (§4.3) so the peer can measure RTT from the echo. PAWS
+// (§5) is not implemented.
 func (h *Handler) processTimestamps(opts []byte, seg Segment, prevRcvNxt Value) {
 	tsval, _, present := h.timestampFromOptions(opts)
 	if seg.Flags.HasAny(FlagSYN) {
@@ -479,8 +489,15 @@ func (h *Handler) processTimestamps(opts []byte, seg Segment, prevRcvNxt Value) 
 	if !h.scb.tsEnabled || !present {
 		return
 	}
-	if seg.SEQ == prevRcvNxt {
-		h.scb.tsRecent = tsval // update echo only for in-order segments (§4.3).
+	// RFC 7323 §4.3: advance TS.Recent only when this segment's TSval is not
+	// older (modular comparison) than the stored value AND the segment lies at or
+	// below Last.ACK.sent (approximated by rcv.NXT captured before this segment).
+	// This prevents a reordered or duplicate ACK carrying a stale TSval from
+	// moving TS.Recent backwards, which would corrupt the echoed timestamp.
+	notOlder := int32(tsval-h.scb.tsRecent) >= 0
+	atOrBelowAckSent := !prevRcvNxt.LessThan(seg.SEQ) // seg.SEQ <= Last.ACK.sent.
+	if notOlder && atOrBelowAckSent {
+		h.scb.tsRecent = tsval
 	}
 }
 
@@ -512,6 +529,12 @@ func (h *Handler) Close() error {
 func (h *Handler) Send(b []byte) (int, error) {
 	if h.IsTxOver() {
 		return 0, net.ErrClosed
+	}
+	if len(b) < sizeHeaderTCP+maxTCPOptionBytes {
+		// Guarantee room for the fixed header plus the largest possible TCP
+		// option area, so appendSegmentOptions can never index past the buffer
+		// once options (Timestamps, MSS, ...) are negotiated.
+		return 0, lneto.ErrShortBuffer
 	}
 	var now int64
 	if h.lossEnabled() {

--- a/tcp/handler.go
+++ b/tcp/handler.go
@@ -1,6 +1,7 @@
 package tcp
 
 import (
+	"encoding/binary"
 	"io"
 	"net"
 
@@ -39,6 +40,9 @@ type Handler struct {
 	// whenever loss is non-nil (enforced by [Conn.Configure]). See [LossRecovery].
 	loss     LossRecovery
 	nanotime func() int64
+	// tsPermit enables offering/accepting the RFC 7323 Timestamps option during
+	// the handshake. Off by default. See [Handler.EnableTimestamps].
+	tsPermit bool
 
 	closing    bool
 	shutdownRx bool
@@ -90,6 +94,44 @@ func (h *Handler) SetLossRecovery(loss LossRecovery, nanotime func() int64) {
 }
 
 func (h *Handler) lossEnabled() bool { return h.loss != nil }
+
+// EnableTimestamps enables the RFC 7323 TCP Timestamps option, which is then
+// offered on the SYN and, if the peer also supports it, echoed on every segment
+// so both ends can measure the round-trip time. It is disabled by default and
+// must be set before the connection is opened. A monotonic time source
+// ([ConnConfig.Nanotime]) is required to negotiate it. Returns
+// [lneto.ErrBadState] if the connection is open.
+func (h *Handler) EnableTimestamps(enable bool) error {
+	if !h.scb.State().IsClosed() {
+		return lneto.ErrBadState
+	}
+	h.tsPermit = enable
+	return nil
+}
+
+// nanosPerMilli converts the monotonic nanosecond time source to the
+// millisecond-resolution TCP timestamp clock (RFC 7323 §4.1).
+const nanosPerMilli = 1_000_000
+
+// clockReady reports whether a monotonic time source has been configured (via
+// [ConnConfig.Nanotime]), enabling the Handler's time-based features such as the
+// RFC 7323 Timestamps option. The tcp package keeps no clock of its own;
+// nanotime is only read to stamp segments.
+func (h *Handler) clockReady() bool { return h.nanotime != nil }
+
+// tsValue returns the local timestamp-clock value for the TSval field: a
+// millisecond-resolution monotonic counter (RFC 7323 §4.1) derived from the
+// configured nanotime source. Returns 0 when no time source is set.
+func (h *Handler) tsValue() uint32 {
+	if h.nanotime == nil {
+		return 0
+	}
+	return uint32(h.nanotime() / nanosPerMilli)
+}
+
+// TimestampsEnabled reports whether the RFC 7323 Timestamps option was
+// negotiated for the current connection.
+func (h *Handler) TimestampsEnabled() bool { return h.scb.tsEnabled }
 
 // NextDeadline returns the monotonic-nanosecond instant at which the connection
 // must next be serviced by a transmit attempt (e.g. an RTO expiry), or 0 when
@@ -167,6 +209,7 @@ func (h *Handler) reset(localPort, remotePort uint16, iss Value) {
 		validator: h.validator,
 		loss:      h.loss,
 		nanotime:  h.nanotime,
+		tsPermit:  h.tsPermit,
 		logger:    h.logger,
 		// persist memory across repoen:
 		bufTx: h.bufTx,
@@ -229,7 +272,8 @@ func (h *Handler) Recv(incomingPacket []byte) error {
 	}
 
 	prevState := h.scb.State()
-	prevUNA := h.scb.snd.UNA // Capture before Recv updates snd.UNA (RFC 6298 §5.3).
+	prevUNA := h.scb.snd.UNA       // Capture before Recv updates snd.UNA (RFC 6298 §5.3).
+	prevRcvNxt := h.scb.RecvNext() // Capture before Recv to detect in-order delivery.
 	err = h.scb.Recv(segIncoming)
 	if err != nil {
 		if h.scb.State() == StateClosed {
@@ -274,6 +318,7 @@ func (h *Handler) Recv(incomingPacket []byte) error {
 			h.bufTx.RecvACK(segIncoming.ACK)
 		}
 	}
+	h.processTimestamps(tfrm.Options(), segIncoming, prevRcvNxt)
 	if segIncoming.Flags.HasAny(FlagSYN) {
 		// Parse remote MSS from TCP options.
 		h.optcodec.ForEachOption(tfrm.Options(), func(kind OptionKind, data []byte) error {
@@ -348,6 +393,87 @@ func (h *Handler) deliverReassembled() {
 	if delivered := h.reasm.reassemble(&h.bufRx, h.scb.RecvNext()); delivered > 0 {
 		h.scb.rcv.NXT.UpdateForward(delivered)
 		h.scb.pending[0] |= FlagACK
+	}
+}
+
+// reservedOptionsLen returns the number of option bytes to reserve ahead of the
+// payload on an established-state segment (a multiple of 4). Data segments carry
+// only the Timestamps option when negotiated.
+func (h *Handler) reservedOptionsLen() int {
+	if h.scb.tsEnabled {
+		return 12 // NOP, NOP, Timestamps(10).
+	}
+	return 0
+}
+
+// appendSegmentOptions writes the TCP options for an outgoing segment into dst
+// (which begins right after the 20-byte fixed header) and returns the number of
+// bytes written, always a multiple of 4 (NOP-padded). mss is advertised on SYN
+// segments.
+func (h *Handler) appendSegmentOptions(dst []byte, seg Segment, mss uint16) int {
+	n := 0
+	if seg.Flags.HasAny(FlagSYN) {
+		m, _ := h.optcodec.PutOption16(dst[n:], OptMaxSegmentSize, mss)
+		n += m
+	}
+	// Timestamps (RFC 7323): offer on a bare SYN when locally permitted;
+	// otherwise include only once negotiated (SYN-ACK and established segments).
+	// The option carries a clock reading, so it is only ever emitted when a time
+	// source has been injected (see [Handler.EnableTimestamps]).
+	includeTS := h.scb.tsEnabled
+	if seg.Flags == FlagSYN {
+		includeTS = h.tsPermit && h.clockReady()
+	}
+	if includeTS {
+		dst[n] = byte(OptNop)
+		dst[n+1] = byte(OptNop)
+		n += 2
+		var ts [8]byte
+		binary.BigEndian.PutUint32(ts[0:], h.tsValue())
+		binary.BigEndian.PutUint32(ts[4:], h.scb.tsRecent)
+		m, _ := h.optcodec.PutOption(dst[n:], OptTimestamps, ts[:]...)
+		n += m
+	}
+	for n%4 != 0 { // pad to a 32-bit boundary.
+		dst[n] = byte(OptNop)
+		n++
+	}
+	return n
+}
+
+// timestampFromOptions extracts the TCP Timestamps option (RFC 7323) from opts.
+func (h *Handler) timestampFromOptions(opts []byte) (tsval, tsecr uint32, present bool) {
+	h.optcodec.ForEachOption(opts, func(kind OptionKind, data []byte) error {
+		if kind == OptTimestamps && len(data) == 8 {
+			tsval = binary.BigEndian.Uint32(data[0:])
+			tsecr = binary.BigEndian.Uint32(data[4:])
+			present = true
+		}
+		return nil
+	})
+	return tsval, tsecr, present
+}
+
+// processTimestamps negotiates and applies the RFC 7323 Timestamps option for an
+// accepted incoming segment: it negotiates support on the SYN and refreshes the
+// echoed TS.Recent value for in-order segments (§4.3) so the peer can measure
+// RTT from the echo.
+func (h *Handler) processTimestamps(opts []byte, seg Segment, prevRcvNxt Value) {
+	tsval, _, present := h.timestampFromOptions(opts)
+	if seg.Flags.HasAny(FlagSYN) {
+		// Only negotiate when a time source is available: the option is
+		// meaningless without one and tsValue would have nothing to read.
+		if present && h.tsPermit && h.clockReady() {
+			h.scb.tsEnabled = true
+			h.scb.tsRecent = tsval
+		}
+		return
+	}
+	if !h.scb.tsEnabled || !present {
+		return
+	}
+	if seg.SEQ == prevRcvNxt {
+		h.scb.tsRecent = tsval // update echo only for in-order segments (§4.3).
 	}
 }
 
@@ -427,8 +553,8 @@ func (h *Handler) Send(b []byte) (int, error) {
 	if awaitingSyn || requeueControl && h.scb.State() == StateSynSent {
 		// Handling init syn segment.
 		segment = ClientSynSegment(h.bufTx.iss, Size(h.bufRx.Size()))
-		h.optcodec.PutOption16(b[sizeHeaderTCP:], OptMaxSegmentSize, mss)
-		offset++
+		optLen := h.appendSegmentOptions(b[sizeHeaderTCP:], segment, mss)
+		offset += uint8(optLen / 4)
 		if requeueControl {
 			h.info("tcp.Handler:requeue-syn", slog.Uint64("port", uint64(h.localPort)), slog.Uint64("rport", uint64(h.remotePort)))
 		}
@@ -439,25 +565,28 @@ func (h *Handler) Send(b []byte) (int, error) {
 			WND:   Size(h.bufRx.Free()),
 			Flags: synack,
 		}
-		h.optcodec.PutOption16(b[sizeHeaderTCP:], OptMaxSegmentSize, mss)
-		offset++
+		optLen := h.appendSegmentOptions(b[sizeHeaderTCP:], segment, mss)
+		offset += uint8(optLen / 4)
 		h.info("tcp.Handler:requeue-synack", slog.Uint64("port", uint64(h.localPort)), slog.Uint64("rport", uint64(h.remotePort)))
 	} else if requeueControl {
 		h.requeueControl = false
 		return 0, nil
 	} else {
 		var ok bool
-		maxPayload := len(b) - sizeHeaderTCP
+		// Reserve room for this segment's TCP options ahead of the payload.
+		optLen := h.reservedOptionsLen()
+		maxPayload := len(b) - sizeHeaderTCP - optLen
 		segment, ok = h.scb.PendingSegment(maxPayload)
 		segment.WND = h.recvWindow()
 		if !ok {
 			// No pending control segment or data to send. Yield.
 			return 0, nil
-		} else if segment.Flags == synack {
-			h.optcodec.PutOption16(b[sizeHeaderTCP:], OptMaxSegmentSize, mss)
-			offset++
-		} else if segment.DATALEN > 0 {
-			n, err := h.bufTx.MakePacket(b[sizeHeaderTCP:sizeHeaderTCP+segment.DATALEN], segment.SEQ)
+		}
+		optLen = h.appendSegmentOptions(b[sizeHeaderTCP:], segment, mss)
+		offset += uint8(optLen / 4)
+		if segment.DATALEN > 0 {
+			dataStart := sizeHeaderTCP + optLen
+			n, err := h.bufTx.MakePacket(b[dataStart:dataStart+int(segment.DATALEN)], segment.SEQ)
 			if err != nil {
 				return 0, err
 			}

--- a/tcp/rto.go
+++ b/tcp/rto.go
@@ -114,14 +114,25 @@ func (r *RTO) PreRx(incoming Segment, now int64) RxDirective {
 		return RxDirective{Keep: true}
 	}
 	ack := incoming.ACK
-	if r.timing && !ack.LessThan(r.timedSeq) {
-		// ACK covers the timed segment: take the RTT sample (§4). A valid
-		// measurement collapses the backoff (§5.7).
+	advanced := r.sndUNA.LessThan(ack) && !r.sndNXT.LessThan(ack)
+	if incoming.TSEcr != 0 && advanced {
+		// RFC 7323 timestamp RTT (§4.2): a sample on every acknowledgment,
+		// unaffected by Karn's retransmission ambiguity. Prefer it over the Karn
+		// sample and supersede any measurement in flight. TSEcr and the timestamp
+		// clock are millisecond-resolution (RFC 7323 §4.1).
+		if rttMS := int64(uint32(now/nanosPerMilli) - incoming.TSEcr); rttMS >= 0 {
+			r.updateRTT(time.Duration(rttMS) * time.Millisecond)
+			r.backoff = 0
+			r.timing = false
+		}
+	} else if r.timing && !ack.LessThan(r.timedSeq) {
+		// No timestamp sample: fall back to Karn's algorithm — the ACK covers the
+		// single timed segment (§4). A valid measurement collapses backoff (§5.7).
 		r.updateRTT(time.Duration(now - r.timedAt))
 		r.timing = false
 		r.backoff = 0
 	}
-	if r.sndUNA.LessThan(ack) && !r.sndNXT.LessThan(ack) {
+	if advanced {
 		// ACK advances snd.UNA and does not exceed what we have sent.
 		r.sndUNA = ack
 	}

--- a/tcp/rto.go
+++ b/tcp/rto.go
@@ -28,6 +28,12 @@ const (
 	// backoffMax caps the exponential-backoff doublings so RTO arithmetic cannot
 	// overflow and a wedged connection keeps probing at rtoMax.
 	backoffMax = 12
+
+	// maxTimestampRTTMillis bounds a plausible RFC 7323 timestamp RTT sample. A
+	// future, stale or malformed echo yields a difference outside [0, this] and
+	// is discarded rather than folded into the estimator. Chosen well above rtoMax
+	// so no realistic path is rejected.
+	maxTimestampRTTMillis = 120_000 // 2 minutes.
 )
 
 // RTO implements the RFC 6298 round-trip-time estimator and the single
@@ -115,13 +121,17 @@ func (r *RTO) PreRx(incoming Segment, now int64) RxDirective {
 	}
 	ack := incoming.ACK
 	advanced := r.sndUNA.LessThan(ack) && !r.sndNXT.LessThan(ack)
-	if incoming.TSEcr != 0 && advanced {
+	if incoming.TSPresent && advanced {
 		// RFC 7323 timestamp RTT (§4.2): a sample on every acknowledgment,
 		// unaffected by Karn's retransmission ambiguity. Prefer it over the Karn
 		// sample and supersede any measurement in flight. TSEcr and the timestamp
-		// clock are millisecond-resolution (RFC 7323 §4.1).
-		if rttMS := int64(uint32(now/nanosPerMilli) - incoming.TSEcr); rttMS >= 0 {
-			r.updateRTT(time.Duration(rttMS) * time.Millisecond)
+		// clock are millisecond-resolution (RFC 7323 §4.1). The difference is a
+		// signed modular subtraction so timestamp-clock wraparound is handled;
+		// a negative (future/stale echo) or implausibly large sample is rejected
+		// so a malformed TSecr cannot poison SRTT/RTO.
+		deltaMS := int32(uint32(now/nanosPerMilli) - incoming.TSEcr)
+		if deltaMS >= 0 && int64(deltaMS) <= maxTimestampRTTMillis {
+			r.updateRTT(time.Duration(deltaMS) * time.Millisecond)
 			r.backoff = 0
 			r.timing = false
 		}

--- a/tcp/rto_test.go
+++ b/tcp/rto_test.go
@@ -188,6 +188,47 @@ func TestRTO_UpdateRTTFirstSample(t *testing.T) {
 	}
 }
 
+// TestRTO_TimestampRTT verifies an ACK carrying an RFC 7323 echo (TSEcr) yields
+// an RTT sample from the timestamp clock and supersedes the Karn sample.
+func TestRTO_TimestampRTT(t *testing.T) {
+	r := newRTO()
+	const iss = uint32(1000)
+	r.PostTx(rtoDataSeg(iss, 100), 100*rtoMs) // sent at ms clock 100.
+
+	seg := rtoAckSeg(iss + 100)
+	seg.TSEcr = 100         // peer echoes the ms clock the data was sent at.
+	r.PreRx(seg, 140*rtoMs) // received at ms clock 140: RTT = 40ms.
+	if r.SmoothedRTT() != 40*time.Millisecond {
+		t.Errorf("srtt=%v, want 40ms from timestamp RTT", r.SmoothedRTT())
+	}
+	if r.timing {
+		t.Error("timestamp sample must supersede the Karn sample in flight")
+	}
+}
+
+// TestRTO_TimestampRTTSurvivesRetransmit verifies the timestamp echo produces an
+// RTT sample even after a retransmission, when Karn's algorithm refuses one.
+func TestRTO_TimestampRTTSurvivesRetransmit(t *testing.T) {
+	r := newRTO()
+	const iss = uint32(1000)
+	r.PostTx(rtoDataSeg(iss, 100), 100*rtoMs) // original send.
+	r.PreTx(int64(rtoInitial) + 100*rtoMs)    // timeout: retransmit, Karn sample discarded.
+	r.PostTx(rtoDataSeg(iss, 100), 200*rtoMs) // retransmit: no Karn sample.
+
+	seg := rtoAckSeg(iss + 100)
+	seg.TSEcr = 200         // peer echoes the retransmit's TSval.
+	r.PreRx(seg, 250*rtoMs) // 50ms after the retransmit.
+	if !r.haveRTT {
+		t.Fatal("timestamp RTT must produce a sample even after a retransmit")
+	}
+	if r.SmoothedRTT() != 50*time.Millisecond {
+		t.Errorf("srtt=%v, want 50ms", r.SmoothedRTT())
+	}
+	if r.backoff != 0 {
+		t.Errorf("backoff=%d, want 0 after a valid timestamp sample", r.backoff)
+	}
+}
+
 // TestRTO_ImplementsLossRecovery exercises RTO through the [LossRecovery]
 // interface: sending data arms a deadline and a full ACK disarms it.
 func TestRTO_ImplementsLossRecovery(t *testing.T) {

--- a/tcp/rto_test.go
+++ b/tcp/rto_test.go
@@ -196,8 +196,8 @@ func TestRTO_TimestampRTT(t *testing.T) {
 	r.PostTx(rtoDataSeg(iss, 100), 100*rtoMs) // sent at ms clock 100.
 
 	seg := rtoAckSeg(iss + 100)
-	seg.TSEcr = 100         // peer echoes the ms clock the data was sent at.
-	r.PreRx(seg, 140*rtoMs) // received at ms clock 140: RTT = 40ms.
+	seg.TSEcr, seg.TSPresent = 100, true // peer echoes the ms clock the data was sent at.
+	r.PreRx(seg, 140*rtoMs)              // received at ms clock 140: RTT = 40ms.
 	if r.SmoothedRTT() != 40*time.Millisecond {
 		t.Errorf("srtt=%v, want 40ms from timestamp RTT", r.SmoothedRTT())
 	}
@@ -216,8 +216,8 @@ func TestRTO_TimestampRTTSurvivesRetransmit(t *testing.T) {
 	r.PostTx(rtoDataSeg(iss, 100), 200*rtoMs) // retransmit: no Karn sample.
 
 	seg := rtoAckSeg(iss + 100)
-	seg.TSEcr = 200         // peer echoes the retransmit's TSval.
-	r.PreRx(seg, 250*rtoMs) // 50ms after the retransmit.
+	seg.TSEcr, seg.TSPresent = 200, true // peer echoes the retransmit's TSval.
+	r.PreRx(seg, 250*rtoMs)              // 50ms after the retransmit.
 	if !r.haveRTT {
 		t.Fatal("timestamp RTT must produce a sample even after a retransmit")
 	}
@@ -226,6 +226,47 @@ func TestRTO_TimestampRTTSurvivesRetransmit(t *testing.T) {
 	}
 	if r.backoff != 0 {
 		t.Errorf("backoff=%d, want 0 after a valid timestamp sample", r.backoff)
+	}
+}
+
+// TestRTO_TimestampRTTZeroEcrValid verifies a zero TSEcr is a valid echo (not
+// treated as "absent") when the option was present: data sent at ms clock 0,
+// acked at ms clock 5, yields a 5ms sample.
+func TestRTO_TimestampRTTZeroEcrValid(t *testing.T) {
+	r := newRTO()
+	const iss = uint32(1000)
+	r.PostTx(rtoDataSeg(iss, 100), 0) // sent at ms clock 0 -> TSval 0.
+
+	seg := rtoAckSeg(iss + 100)
+	seg.TSEcr, seg.TSPresent = 0, true // valid zero echo.
+	r.PreRx(seg, 5*rtoMs)
+	if r.SmoothedRTT() != 5*time.Millisecond {
+		t.Errorf("srtt=%v, want 5ms from a zero-TSEcr sample", r.SmoothedRTT())
+	}
+}
+
+// TestRTO_TimestampRTTRejectsImplausible verifies future (negative modular delta)
+// and implausibly large echoes are discarded rather than poisoning SRTT/RTO.
+func TestRTO_TimestampRTTRejectsImplausible(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		tsecr     uint32
+		nowMillis int64
+	}{
+		{"future echo", 1000, 500},                               // echo ahead of the clock.
+		{"absurdly stale", 1, int64(maxTimestampRTTMillis) + 10}, // delta beyond the plausibility cap.
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRTO()
+			const iss = uint32(1000)
+			r.PostTx(rtoDataSeg(iss, 100), 0)
+			seg := rtoAckSeg(iss + 100)
+			seg.TSEcr, seg.TSPresent = tc.tsecr, true
+			r.PreRx(seg, tc.nowMillis*rtoMs)
+			if r.haveRTT {
+				t.Errorf("implausible timestamp echo produced an RTT sample (srtt=%v)", r.SmoothedRTT())
+			}
+		})
 	}
 }
 

--- a/tcp/timestamps_test.go
+++ b/tcp/timestamps_test.go
@@ -3,6 +3,7 @@ package tcp
 import (
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/soypat/lneto/ethernet"
 )
@@ -113,5 +114,59 @@ func TestTimestamps_EchoOnDataSegment(t *testing.T) {
 	}
 	if server.scb.tsRecent != 12 {
 		t.Errorf("server TS.Recent = %d, want client TSval 12", server.scb.tsRecent)
+	}
+}
+
+// TestTimestamps_MeasuresRTTThroughHandler drives a full data/ack exchange with
+// timestamps and an RTO installed on the client, and verifies the round-trip
+// time is measured from the echoed timestamp end to end (RFC 7323 §4.2).
+func TestTimestamps_MeasuresRTTThroughHandler(t *testing.T) {
+	const mtu = ethernet.MaxMTU
+	rng := rand.New(rand.NewSource(4))
+	client, server := newHandler(t, mtu, 3), newHandler(t, mtu, 3)
+
+	clientNS := int64(1000 * nanosPerMilli)
+	rto := new(RTO)
+	client.SetLossRecovery(rto, func() int64 { return clientNS })
+	if err := client.EnableTimestamps(true); err != nil {
+		t.Fatal("client EnableTimestamps:", err)
+	}
+	serverNS := int64(9 * nanosPerMilli)
+	enableTimestamps(t, server, &serverNS)
+
+	setupClientServer(t, rng, client, server)
+	var buf [mtu]byte
+	establish(t, client, server, buf[:])
+
+	// Client sends data at ms clock 1000.
+	data := []byte("payload")
+	if _, err := client.Write(data); err != nil {
+		t.Fatal("client write:", err)
+	}
+	clear(buf[:])
+	n, err := client.Send(buf[:])
+	if err != nil {
+		t.Fatal("client send data:", err)
+	}
+	if err := server.Recv(buf[:n]); err != nil {
+		t.Fatal("server recv data:", err)
+	}
+	// Server acknowledges, echoing the client's TSval (1000).
+	clear(buf[:])
+	n, err = server.Send(buf[:])
+	if err != nil {
+		t.Fatal("server send ack:", err)
+	}
+	if n < sizeHeaderTCP {
+		t.Fatal("expected server to send an ACK")
+	}
+
+	// The ACK arrives 40ms later; the RTO measures RTT from the echo.
+	clientNS = 1040 * nanosPerMilli
+	if err := client.Recv(buf[:n]); err != nil {
+		t.Fatal("client recv ack:", err)
+	}
+	if rto.SmoothedRTT() != 40*time.Millisecond {
+		t.Errorf("measured RTT = %v, want 40ms", rto.SmoothedRTT())
 	}
 }

--- a/tcp/timestamps_test.go
+++ b/tcp/timestamps_test.go
@@ -1,10 +1,12 @@
 package tcp
 
 import (
+	"encoding/binary"
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/soypat/lneto"
 	"github.com/soypat/lneto/ethernet"
 )
 
@@ -168,5 +170,95 @@ func TestTimestamps_MeasuresRTTThroughHandler(t *testing.T) {
 	}
 	if rto.SmoothedRTT() != 40*time.Millisecond {
 		t.Errorf("measured RTT = %v, want 40ms", rto.SmoothedRTT())
+	}
+}
+
+// tsOption builds a bare RFC 7323 Timestamps option (no NOP padding) carrying
+// tsval/tsecr, as it would appear in a segment's option area.
+func tsOption(tsval, tsecr uint32) []byte {
+	opt := []byte{byte(OptTimestamps), 10, 0, 0, 0, 0, 0, 0, 0, 0}
+	binary.BigEndian.PutUint32(opt[2:], tsval)
+	binary.BigEndian.PutUint32(opt[6:], tsecr)
+	return opt
+}
+
+// TestTimestamps_TSRecentNoRegression verifies TS.Recent follows RFC 7323 §4.3:
+// a reordered/duplicate segment carrying an older TSval must not move it back,
+// while a newer TSval at or below Last.ACK.sent advances it.
+func TestTimestamps_TSRecentNoRegression(t *testing.T) {
+	const mtu = ethernet.MaxMTU
+	h := newHandler(t, mtu, 3)
+	h.scb.tsEnabled = true
+	h.scb.tsRecent = 100
+	seg := Segment{SEQ: 5, Flags: FlagACK}
+	const prevRcvNxt = Value(10) // seg.SEQ (5) <= Last.ACK.sent (10).
+
+	h.processTimestamps(tsOption(50, 0), seg, prevRcvNxt) // older TSval.
+	if h.scb.tsRecent != 100 {
+		t.Errorf("TS.Recent moved backwards to %d on an older TSval, want 100", h.scb.tsRecent)
+	}
+	h.processTimestamps(tsOption(150, 0), seg, prevRcvNxt) // newer TSval.
+	if h.scb.tsRecent != 150 {
+		t.Errorf("TS.Recent = %d after a newer TSval, want 150", h.scb.tsRecent)
+	}
+}
+
+// TestTimestamps_DropSegmentMissingOption verifies that once timestamps are
+// negotiated a non-RST segment lacking the option is silently dropped (RFC 7323
+// §3.2): it is neither buffered nor advances connection state.
+func TestTimestamps_DropSegmentMissingOption(t *testing.T) {
+	const mtu = ethernet.MaxMTU
+	rng := rand.New(rand.NewSource(5))
+	client, server := newHandler(t, mtu, 3), newHandler(t, mtu, 3)
+	clientNS, serverNS := int64(5*nanosPerMilli), int64(9*nanosPerMilli)
+	enableTimestamps(t, client, &clientNS)
+	enableTimestamps(t, server, &serverNS)
+	setupClientServer(t, rng, client, server)
+	var buf [mtu]byte
+	establish(t, client, server, buf[:])
+
+	// Craft an in-order data segment carrying no options (data offset = 5).
+	data := []byte("nooption")
+	seg := Segment{
+		SEQ:     server.scb.RecvNext(),
+		ACK:     client.scb.RecvNext(),
+		WND:     4096,
+		Flags:   FlagACK,
+		DATALEN: Size(len(data)),
+	}
+	var raw [mtu]byte
+	frame, err := NewFrame(raw[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	frame.SetSourcePort(client.LocalPort())
+	frame.SetDestinationPort(server.LocalPort())
+	frame.SetSegment(seg, 5) // offset 5 => 20-byte header, no options.
+	frame.SetUrgentPtr(0)
+	copy(raw[sizeHeaderTCP:], data)
+
+	if err := server.Recv(raw[:sizeHeaderTCP+len(data)]); err != nil {
+		t.Fatalf("dropped segment must return nil, got %v", err)
+	}
+	if server.BufferedInput() != 0 {
+		t.Fatalf("segment missing TSopt must not be buffered, got %d bytes", server.BufferedInput())
+	}
+	if server.State() != StateEstablished {
+		t.Fatalf("segment missing TSopt must not change state, got %s", server.State())
+	}
+}
+
+// TestTimestamps_SendShortBufferErrors verifies Send returns ErrShortBuffer
+// (rather than panicking) when the buffer cannot hold the header plus the
+// maximum TCP option area.
+func TestTimestamps_SendShortBufferErrors(t *testing.T) {
+	const mtu = ethernet.MaxMTU
+	h := newHandler(t, mtu, 3)
+	if err := h.OpenActive(1234, 5678, 0); err != nil {
+		t.Fatal(err)
+	}
+	small := make([]byte, sizeHeaderTCP+maxTCPOptionBytes-1)
+	if _, err := h.Send(small); err != lneto.ErrShortBuffer {
+		t.Fatalf("Send with a short buffer = %v, want ErrShortBuffer", err)
 	}
 }

--- a/tcp/timestamps_test.go
+++ b/tcp/timestamps_test.go
@@ -1,0 +1,117 @@
+package tcp
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/soypat/lneto/ethernet"
+)
+
+// enableTimestamps turns on RFC 7323 timestamps for h and installs a monotonic
+// clock reading *nowNS nanoseconds (no loss recovery). Must be called before the
+// connection is opened.
+func enableTimestamps(t *testing.T, h *Handler, nowNS *int64) {
+	t.Helper()
+	h.SetLossRecovery(nil, func() int64 { return *nowNS })
+	if err := h.EnableTimestamps(true); err != nil {
+		t.Fatal("EnableTimestamps:", err)
+	}
+}
+
+// TestTimestamps_NegotiatedWhenBothEnable verifies the option is negotiated on
+// the handshake when both peers permit it and a clock is present.
+func TestTimestamps_NegotiatedWhenBothEnable(t *testing.T) {
+	const mtu = ethernet.MaxMTU
+	rng := rand.New(rand.NewSource(1))
+	client, server := newHandler(t, mtu, 3), newHandler(t, mtu, 3)
+	clientNS, serverNS := int64(5*nanosPerMilli), int64(9*nanosPerMilli)
+	enableTimestamps(t, client, &clientNS)
+	enableTimestamps(t, server, &serverNS)
+
+	setupClientServer(t, rng, client, server)
+	var buf [mtu]byte
+	establish(t, client, server, buf[:])
+
+	if !client.TimestampsEnabled() {
+		t.Error("client did not negotiate timestamps")
+	}
+	if !server.TimestampsEnabled() {
+		t.Error("server did not negotiate timestamps")
+	}
+}
+
+// TestTimestamps_NotNegotiatedWhenOneSideOff verifies the option stays off for
+// the whole connection when either peer does not permit it.
+func TestTimestamps_NotNegotiatedWhenOneSideOff(t *testing.T) {
+	const mtu = ethernet.MaxMTU
+	rng := rand.New(rand.NewSource(2))
+	client, server := newHandler(t, mtu, 3), newHandler(t, mtu, 3)
+	clientNS := int64(5 * nanosPerMilli)
+	enableTimestamps(t, client, &clientNS) // only the client permits timestamps.
+
+	setupClientServer(t, rng, client, server)
+	var buf [mtu]byte
+	establish(t, client, server, buf[:])
+
+	if client.TimestampsEnabled() {
+		t.Error("client negotiated timestamps without server support")
+	}
+	if server.TimestampsEnabled() {
+		t.Error("server negotiated timestamps though it was disabled")
+	}
+}
+
+// TestTimestamps_EchoOnDataSegment verifies an established data segment carries
+// the Timestamps option: TSval is the sender's current clock and TSecr echoes
+// the most recent value received from the peer (RFC 7323 §3.2).
+func TestTimestamps_EchoOnDataSegment(t *testing.T) {
+	const mtu = ethernet.MaxMTU
+	rng := rand.New(rand.NewSource(3))
+	client, server := newHandler(t, mtu, 3), newHandler(t, mtu, 3)
+	clientNS, serverNS := int64(5*nanosPerMilli), int64(9*nanosPerMilli)
+	enableTimestamps(t, client, &clientNS)
+	enableTimestamps(t, server, &serverNS)
+
+	setupClientServer(t, rng, client, server)
+	var buf [mtu]byte
+	establish(t, client, server, buf[:])
+
+	// The client learned the server's TSval (9) from the SYN-ACK.
+	if client.scb.tsRecent != 9 {
+		t.Fatalf("client TS.Recent = %d, want server TSval 9", client.scb.tsRecent)
+	}
+
+	// Advance the client clock, then send a data segment.
+	clientNS = 12 * nanosPerMilli
+	data := []byte("payload")
+	if _, err := client.Write(data); err != nil {
+		t.Fatal("client write:", err)
+	}
+	clear(buf[:])
+	n, err := client.Send(buf[:])
+	if err != nil {
+		t.Fatal("client send:", err)
+	}
+	frame, err := NewFrame(buf[:n])
+	if err != nil {
+		t.Fatal("parse frame:", err)
+	}
+	tsval, tsecr, present := client.timestampFromOptions(frame.Options())
+	if !present {
+		t.Fatal("data segment carried no Timestamps option")
+	}
+	if tsval != 12 {
+		t.Errorf("TSval = %d, want current client clock 12", tsval)
+	}
+	if tsecr != 9 {
+		t.Errorf("TSecr = %d, want echoed server TSval 9", tsecr)
+	}
+
+	// The server records the client's TSval as its new echo on delivery.
+	if err := server.Recv(buf[:n]); err != nil {
+		t.Fatal("server recv:", err)
+	}
+	if server.scb.tsRecent != 12 {
+		t.Errorf("server TS.Recent = %d, want client TSval 12", server.scb.tsRecent)
+	}
+}


### PR DESCRIPTION
Follow up to #155 and split off from #115. This was part of the TCP congestion/loss recovery and is now a standalone PR.