### PR TITLE
fix(xnet): install a retransmission timer on TCP connections

### DIFF
--- a/tcp/control.go
+++ b/tcp/control.go
@@ -279,10 +279,9 @@ func (tcb *ControlBlock) PendingSegment(payloadLen int) (_ Segment, ok bool) {
 		// Optimist Strategy: retransmit oldest data once.
 		return Segment{SEQ: tcb.snd.UNA, DATALEN: Size(payloadLen), ACK: tcb.rcv.NXT, WND: tcb.rcv.WND, Flags: FlagACK}, true
 	}
-	established := tcb._state == StateEstablished
-	canSendData := established || tcb._state == StateCloseWait
+	canSendData := tcb._state.txQueuedDataOpen()
 	if !canSendData {
-		payloadLen = 0 // Can't send data if not established or close-wait.
+		payloadLen = 0 // No send-buffer data may go out in this state.
 	}
 	if pending == 0 && payloadLen == 0 {
 		return Segment{}, false // No pending segment.
@@ -522,8 +521,12 @@ func (tcb *ControlBlock) validateOutgoingSegment(seg Segment) (err error) {
 			err = errSeqNotInWindow
 		}
 
-	case seg.DATALEN > 0 && (tcb._state == StateFinWait1 || tcb._state == StateFinWait2):
-		err = errConnectionClosing // Case 1: No further SENDs from the user will be accepted by the TCP implementation.
+	case seg.DATALEN > 0 && tcb._state == StateFinWait2:
+		// FIN-WAIT-2 means our FIN was acknowledged, so no data below it can be
+		// unacknowledged and data here is a caller error. FIN-WAIT-1 is excluded:
+		// its FIN sits above data the peer may still be missing, which must go out
+		// for either side to make progress (RFC 9293 §3.10.8).
+		err = errConnectionClosing
 
 	case checkSeq && tcb.snd.WND == 0 && seg.DATALEN > 0 && seg.SEQ == tcb.snd.NXT:
 		err = errZeroWindow

--- a/tcp/definitions.go
+++ b/tcp/definitions.go
@@ -329,6 +329,14 @@ func (s State) TxDataOpen() bool {
 	return s == StateEstablished || s == StateCloseWait
 }
 
+// txQueuedDataOpen returns true if already-queued send-buffer data may still be
+// put on the wire. It stays true after a local close, where the FIN occupies a
+// sequence above data the peer has not acknowledged: until that data is
+// (re)transmitted the peer cannot reach the FIN. RFC 9293 §3.10.8.
+func (s State) txQueuedDataOpen() bool {
+	return s.TxDataOpen() || s == StateFinWait1 || s == StateClosing || s == StateLastAck
+}
+
 // RxDataOpen returns true if the state allows the receiving of incoming data segments.
 // Combine with [State.IsPreestablished] to know whether there is no more data to be received over the network.
 func (s State) RxDataOpen() bool {

--- a/tcp/rtointegration_test.go
+++ b/tcp/rtointegration_test.go
@@ -1,0 +1,120 @@
+package tcp
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/soypat/lneto/ethernet"
+)
+
+// TestHandlerRetransmitsAfterRTO covers the seam between a Handler and its
+// LossRecovery, which the RTO unit tests do not: a lost data segment must be
+// resent once the timer expires, with nothing arriving to prompt it.
+func TestHandlerRetransmitsAfterRTO(t *testing.T) {
+	const mtu = ethernet.MaxMTU
+	const maxpackets = 4
+	rng := rand.New(rand.NewSource(5))
+	client, server := newHandler(t, mtu, maxpackets), newHandler(t, mtu, maxpackets)
+
+	var now int64 // injected monotonic clock, in nanoseconds
+	client.SetLossRecovery(new(RTO), func() int64 { return now })
+
+	setupClientServer(t, rng, client, server)
+	var rawbuf [mtu]byte
+	establish(t, client, server, rawbuf[:])
+
+	data := []byte("hello")
+	if n, err := client.Write(data); err != nil || n != len(data) {
+		t.Fatal("client write:", n, err)
+	}
+	clear(rawbuf[:])
+	n, err := client.Send(rawbuf[:])
+	if err != nil || n == 0 {
+		t.Fatal("client send:", n, err)
+	}
+	// That frame is lost: it is never handed to the server.
+
+	// Nothing may come back before the timer expires.
+	var probe [mtu]byte
+	if n, err := client.Send(probe[:]); err != nil || n != 0 {
+		t.Fatalf("client sent %d bytes before the RTO expired (err %v)", n, err)
+	}
+
+	now += int64(3 * time.Second) // past the initial RTO and one backoff
+
+	clear(probe[:])
+	n, err = client.Send(probe[:])
+	if err != nil {
+		t.Fatal("client send after RTO:", err)
+	}
+	if n == 0 {
+		t.Fatal("no retransmission after the RTO expired: the loss-recovery directive is never applied")
+	}
+	if err := server.Recv(probe[:n]); err != nil {
+		t.Fatal("server refused the retransmission:", err)
+	}
+	got := make([]byte, 16)
+	nr, err := server.Read(got)
+	if err != nil || string(got[:nr]) != string(data) {
+		t.Fatalf("server read %q (%v), want %q", got[:nr], err, data)
+	}
+}
+
+// TestHandlerRetransmitsAfterCloseWithUnackedData is the write-then-close case
+// every server performs. With the last data segment lost, the FIN behind it sits
+// above a gap the peer cannot cross, so FIN-WAIT-1 must still retransmit that
+// data or both sides wait forever.
+func TestHandlerRetransmitsAfterCloseWithUnackedData(t *testing.T) {
+	const mtu = ethernet.MaxMTU
+	const maxpackets = 4
+	rng := rand.New(rand.NewSource(9))
+	client, server := newHandler(t, mtu, maxpackets), newHandler(t, mtu, maxpackets)
+
+	var now int64
+	client.SetLossRecovery(new(RTO), func() int64 { return now })
+
+	setupClientServer(t, rng, client, server)
+	var rawbuf [mtu]byte
+	establish(t, client, server, rawbuf[:])
+
+	data := []byte("last response bytes")
+	if n, err := client.Write(data); err != nil || n != len(data) {
+		t.Fatal("client write:", n, err)
+	}
+	clear(rawbuf[:])
+	n, err := client.Send(rawbuf[:]) // this frame is lost in transit
+	if err != nil || n == 0 {
+		t.Fatal("client send:", n, err)
+	}
+
+	// The application closes right after writing.
+	if err := client.Close(); err != nil {
+		t.Fatal("client close:", err)
+	}
+	var finbuf [mtu]byte
+	nfin, err := client.Send(finbuf[:]) // FIN (also lost, or simply unacked)
+	if err != nil {
+		t.Fatal("client send FIN:", err)
+	}
+	t.Logf("state after close: %s (FIN frame %d bytes)", client.State(), nfin)
+
+	now += int64(3 * time.Second) // past the RTO
+
+	var probe [mtu]byte
+	n, err = client.Send(probe[:])
+	if err != nil {
+		t.Fatal("client send after RTO:", err)
+	}
+	if n == 0 {
+		t.Fatalf("no retransmission in %s: unacknowledged data is stranded by the close", client.State())
+	}
+	if err := server.Recv(probe[:n]); err != nil {
+		t.Fatal("server refused the retransmission:", err)
+	}
+	got := make([]byte, 32)
+	nr, err := server.Read(got)
+	if err != nil || string(got[:nr]) != string(data) {
+		t.Fatalf("server read %q (%v), want %q", got[:nr], err, data)
+	}
+}

--- a/x/xnet/retransmit_test.go
+++ b/x/xnet/retransmit_test.go
@@ -1,0 +1,155 @@
+package xnet
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"runtime"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/soypat/lneto"
+	"github.com/soypat/lneto/ethernet"
+)
+
+// TestTCPRetransmitsLostSegment drops exactly one data segment and requires the
+// bytes to arrive anyway, which is what [TCPPoolConfig.NanoTime] already promises
+// in its own documentation. Without a LossRecovery installed the loss is terminal.
+func TestTCPRetransmitsLostSegment(t *testing.T) {
+	const (
+		MTU     = ethernet.MaxMTU
+		svPort  = 80
+		bufSize = 2 << 10
+	)
+	client, sv := new(StackAsync), new(StackAsync)
+	if err := client.Reset(StackConfig{
+		Hostname:          "rtx-client",
+		RandSeed:          11,
+		StaticAddress4:    [4]byte{10, 0, 0, 90},
+		MaxActiveTCPPorts: 2,
+		HardwareAddress:   [6]byte{0xbe, 0xef, 0, 0, 0, 90},
+		MTU:               MTU,
+		ICMPQueueLimit:    2,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sv.Reset(StackConfig{
+		Hostname:          "rtx-server",
+		RandSeed:          ^int64(11),
+		StaticAddress4:    [4]byte{10, 0, 0, 91},
+		MaxActiveTCPPorts: 2,
+		HardwareAddress:   [6]byte{0xbe, 0xef, 0, 0, 0, 91},
+		MTU:               MTU,
+		ICMPQueueLimit:    2,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	client.SetGatewayHardwareAddr(sv.HardwareAddr())
+	sv.SetGatewayHardwareAddr(client.HardwareAddr())
+
+	pool := TCPPoolConfig{
+		PoolSize: 2, QueueSize: 4,
+		TxBufSize: bufSize, RxBufSize: bufSize,
+		EstablishedTimeout: 30 * time.Second,
+		ClosingTimeout:     30 * time.Second,
+		NewBackoff:         func() lneto.BackoffStrategy { return backoffYield },
+	}
+	svGo := sv.StackBlocking(backoffYield).StackGo(StackGoConfig{ListenerPoolConfig: pool})
+	clGo := client.StackBlocking(backoffYield).StackGo(StackGoConfig{
+		ListenerPoolConfig: pool,
+		TCPDialTimeout:     2 * time.Second,
+		TCPDialRetries:     2,
+	})
+
+	lsAny, err := svGo.SocketNetip(context.Background(), "tcp", syscall.AF_INET, sockSTREAM,
+		netip.AddrPortFrom(netip.AddrFrom4(sv.Addr4()), svPort), netip.AddrPort{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener := lsAny.(net.Listener)
+	defer listener.Close()
+
+	// dropNext arms the pump to swallow the next server→client data frame.
+	var dropNext, dropped atomic.Bool
+	stopPump := make(chan struct{})
+	defer close(stopPump)
+	go func() {
+		buf := make([]byte, MTU+ethernet.MaxOverheadSize)
+		for {
+			select {
+			case <-stopPump:
+				return
+			default:
+			}
+			moved := false
+			if n, err := client.EgressEthernet(buf); err == nil && n > 0 {
+				sv.IngressEthernet(buf[:n])
+				moved = true
+			}
+			if n, err := sv.EgressEthernet(buf); err == nil && n > 0 {
+				// Drop only a data-carrying frame: headers total 54 bytes, so
+				// anything larger has payload. Dropping a bare ACK would test the
+				// other direction's recovery instead.
+				if dropNext.Load() && n > 14+20+20+8 {
+					dropNext.Store(false)
+					dropped.Store(true)
+				} else {
+					client.IngressEthernet(buf[:n])
+				}
+				moved = true
+			}
+			if !moved {
+				runtime.Gosched()
+			}
+		}
+	}()
+
+	served := make(chan error, 1)
+	go func() {
+		c, err := listener.Accept()
+		if err != nil {
+			served <- err
+			return
+		}
+		defer c.Close()
+		c.SetDeadline(time.Now().Add(30 * time.Second))
+		dropNext.Store(true) // the very next data frame is lost
+		_, err = c.Write([]byte("this segment is lost in transit"))
+		served <- err
+	}()
+
+	raddr := netip.AddrPortFrom(netip.AddrFrom4(sv.Addr4()), svPort)
+	cAny, err := clGo.SocketNetip(context.Background(), "tcp", syscall.AF_INET, sockSTREAM,
+		netip.AddrPort{}, raddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn := cAny.(net.Conn)
+	defer conn.Close()
+	// Generous on purpose: the first RTO is one second (RFC 6298 §2.1) and may
+	// back off once. What is under test is that recovery happens at all.
+	conn.SetDeadline(time.Now().Add(15 * time.Second))
+
+	want := "this segment is lost in transit"
+	got := make([]byte, 0, len(want))
+	rb := make([]byte, 64)
+	for len(got) < len(want) {
+		n, err := conn.Read(rb)
+		got = append(got, rb[:n]...)
+		if err != nil {
+			t.Fatalf("read %d/%d bytes after losing one segment (dropped=%v): %v (no retransmission timer?)",
+				len(got), len(want), dropped.Load(), err)
+		}
+	}
+	if string(got) != want {
+		t.Fatalf("read %q, want %q", got, want)
+	}
+	if !dropped.Load() {
+		t.Fatal("no frame was dropped, so the test did not exercise retransmission")
+	}
+	if err := <-served; err != nil {
+		t.Fatalf("server side: %v", err)
+	}
+}

--- a/x/xnet/stack-go.go
+++ b/x/xnet/stack-go.go
@@ -181,6 +181,10 @@ func (s StackGo) SocketNetip(ctx context.Context, network string, family, sotype
 				RxBuf:             make([]byte, s.plcfg.RxBufSize),
 				TxPacketQueueSize: s.plcfg.QueueSize,
 				RWBackoff:         s.plcfg.NewBackoff(),
+				// A dialed connection needs a retransmission timer as much as a
+				// pooled one. See [NewTCPPool].
+				LossRecovery: new(tcp.RTO),
+				Nanotime:     s.blk.nanotime,
 			})
 			if err != nil {
 				return nil, err

--- a/x/xnet/tcppool.go
+++ b/x/xnet/tcppool.go
@@ -87,6 +87,11 @@ func NewTCPPool(cfg TCPPoolConfig) (*TCPPool, error) {
 			TxPacketQueueSize: cfg.QueueSize,
 			Logger:            cfg.ConnLogger,
 			RWBackoff:         cfg.NewBackoff(),
+			// Retransmission timing, as NanoTime's contract promises. One RTO per
+			// connection: it shadows that connection's send sequence space and so
+			// cannot be shared.
+			LossRecovery: new(tcp.RTO),
+			Nanotime:     pool.now,
 		}
 		err := pool.conns[i].Configure(conncfg)
 		if err != nil {


### PR DESCRIPTION
No connection created through `x/xnet` had one. Neither `NewTCPPool` nor the dial
path in `StackGo` set `ConnConfig.LossRecovery` and `ConnConfig.Nanotime`, so
`tcp.Handler` ran with loss recovery disabled: nothing noticed a lost segment,
and the connection simply stopped — the sender waiting for an ACK that cannot
arrive, the receiver for data nobody will resend.

`TCPPoolConfig.NanoTime` already documents itself as:

> NanoTime returns the current monotonic time in nanoseconds. Used for pool
> timeout tracking **and passed to each [tcp.Conn] for retransmission timing
> (RFC 6298)**. If nil, defaults to time.Now().UnixNano().

This makes that true. Each connection gets its own `tcp.RTO`, which shadows that
connection's send sequence space and so cannot be shared: 80 bytes per
connection, allocated once at pool construction, against per-connection buffers
measured in kilobytes. The clock comes from `TCPPool.now`, keeping the existing
`NanoTime` override and its `time.Now` fallback.

### Measurement

A 512 KiB stream through an in-process pump that drops every 23rd data frame:
**2 of 10 runs completed before, 8 of 10 after** (the residual failure is a
separate and rarer stall, still under investigation — not addressed here).

### Test

`TestTCPRetransmitsLostSegment` drops exactly one data segment and requires the
byte to arrive anyway. It depends on #182, since the server closes after writing
and the retransmission then has to leave FIN-WAIT-1.

### If you would rather keep this opt-in

A connection without a retransmission timer cannot recover from any loss, which
is why this wires it unconditionally rather than adding a config knob. But the
call is yours: the alternative is to correct `NanoTime`'s documentation and
expose a hook for callers to supply their own `LossRecovery`. Happy to do it that
way instead — say which you prefer.
