### PR TITLE
xnet: debug packet before ingressing

### DIFF
--- a/x/xnet/stack-async.go
+++ b/x/xnet/stack-async.go
@@ -129,8 +129,8 @@ func (s *StackAsync) IngressEthernet(ethernetFrame []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.stats.TotalReceived += uint64(len(ethernetFrame))
-	err := s.link.Demux(ethernetFrame, 0)
 	debugPacket("IN ", ethernetFrame)
+	err := s.link.Demux(ethernetFrame, 0)
 	if err == nil {
 		s.arpt.learnFromIngressEthernet(ethernetFrame)
 	}


### PR DESCRIPTION
Debugging packet precedes ingress to catch packets which cause crashes within lneto. Although I've not explicitly observed a crash within lneto some behaviour with my LAN8720 server has made me more careful.